### PR TITLE
fixed: calling '.start()' before overlay fades out

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -129,14 +129,20 @@
     //for fade-out animation
     overlayLayer.style.opacity = 0;
     setTimeout(function () {
-      overlayLayer.parentNode.removeChild(overlayLayer);
+      if (overlayLayer.parentNode) {
+        overlayLayer.parentNode.removeChild(overlayLayer);
+      }
     }, 500);
     //remove all helper layers
     var helperLayer = targetElement.querySelector(".introjs-helperLayer");
-    helperLayer.parentNode.removeChild(helperLayer);
+    if (helperLayer) {
+      helperLayer.parentNode.removeChild(helperLayer);
+    }
     //remove `introjs-showElement` class from the element
     var showElement = document.querySelector(".introjs-showElement");
-    showElement.className = showElement.className.replace(/introjs-showElement/,'').trim();
+    if (showElement) {
+      showElement.className = showElement.className.replace(/introjs-showElement/,'').trim();
+    }
     //clean listeners
     targetElement.onkeydown = null;
   }


### PR DESCRIPTION
Fixed `Uncaught TypeError: Cannot read property 'parentNode' of null`: if user fires `.start()` before overlay entirely fades out there is the bug.

![intro-js-start-fire-bug](https://f.cloud.github.com/assets/556770/264719/9edc89be-8d98-11e2-97ef-dcad251e78d9.png)
