### PR TITLE
Fixed several bugs related to IE8 compatibility.

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -11,8 +11,13 @@
     <link href="css/bootstrap.min.css" rel="stylesheet">
     <link href="css/demo.css" rel="stylesheet">
 
-    <!-- Add IntroJs style -->
+    <!-- Add IntroJs styles -->
     <link href="../introjs.css" rel="stylesheet">
+    <!--[if lte IE 8]>
+    <link href="../introjs-ie.css" rel="stylesheet">
+    <!-- <![endif]-->
+    
+
     <link href="css/bootstrap-responsive.min.css" rel="stylesheet">
   </head>
 

--- a/intro.js
+++ b/intro.js
@@ -145,7 +145,7 @@
     //remove `introjs-showElement` class from the element
     var showElement = document.querySelector(".introjs-showElement");
     if (showElement) {
-      showElement.className = showElement.className.replace(/introjs-[a-zA-Z]+/g, '').trim();
+      showElement.className = showElement.className.replace(/introjs-[a-zA-Z]+/g, '').replace(/^\s+|\s+$/g, ''); // This is a manual trim.
     }
     //clean listeners
     window.onkeydown = null;
@@ -225,7 +225,7 @@
       //set current tooltip text
       oldtooltipLayer.innerHTML = targetElement.getAttribute("data-intro");
       var oldShowElement = document.querySelector(".introjs-showElement");
-      oldShowElement.className = oldShowElement.className.replace(/introjs-[a-zA-Z]+/g, '').trim();
+      oldShowElement.className = oldShowElement.className.replace(/introjs-[a-zA-Z]+/g, '').replace(/^\s+|\s+$/g, ''); // This is a manual trim
       _placeTooltip(targetElement, oldtooltipContainer, oldArrowLayer);
     } else {
       var helperLayer = document.createElement("div"),
@@ -312,9 +312,9 @@
     }
 
     if (!_elementInViewport(targetElement)) {
-      var rect = targetElement.getBoundingClientRect()
-          top = rect.bottom - rect.height,
-          bottom = rect.bottom - window.innerHeight;
+      var rect = targetElement.getBoundingClientRect(),
+          top = rect.bottom - (rect.bottom - rect.top),
+          bottom = rect.bottom - _getWinSize().height;
 
       // Scroll up
       if (top < 0) {
@@ -324,6 +324,26 @@
       } else {
         window.scrollBy(0, bottom + 100); // 70px + 30px padding from edge to look nice
       }
+    }
+  }
+
+  /**
+   * Provides a cross-browser way to get the screen dimensions
+   * via: http://stackoverflow.com/questions/5864467/internet-explorer-innerheight
+   *
+   * @api private
+   * @method _getWinSize
+   * @returns {Object} with width and height attributes
+   */
+  function _getWinSize(){
+    if(window.innerWidth!= undefined){
+      return {width: window.innerWidth, height: window.innerHeight};
+    }
+    else{
+      var B = document.body, 
+          D = document.documentElement;
+      return {width: Math.max(D.clientWidth, B.clientWidth),
+              height: Math.max(D.clientHeight, B.clientHeight)};
     }
   }
 

--- a/introjs-ie.css
+++ b/introjs-ie.css
@@ -1,0 +1,9 @@
+.introjs-overlay {
+  background-color: #000;
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
+  filter: alpha(opacity=50);
+}
+.introjs-helperLayer {
+  background-color: #FFF;
+  border-color: #777;
+}


### PR DESCRIPTION
This is intended to address issue #41

Replaced all instances of .trim() with the regex equivalent (IE8 does not support .trim()).

Added method _getWinSize to accurately retrieve window.innerWidth / window.innerHeight since IE8 does not support such calls.

Added conditional IE stylesheet to the index.html file. Stylesheet must be included after intros.css and provides a proper opacity on the backdrop and a full-white highlight area. IE8 does not support RGBA in CSS.

I tested this using Browserstack.com, and I wasn't able to get the keyboard input working, though I can't tell if this is a real issue or just Browserstack.
