### PR TITLE
Added ability to set data-intro value to an element id. The given element contents will be displayed as the step tooltip content

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -32,11 +32,10 @@
       <hr>
 
       <div class="jumbotron">
-        <h1 data-step="1" data-intro="Hello all! :) This project's called Intro.js.">Intro<span style="font-weight: normal;">.js</span></h1>
+        <h1 data-step="1" data-intro="step1-text">Intro<span style="font-weight: normal;">.js</span></h1>
         <p class="lead" data-step="4" data-intro="Let's try it. It's free and open-source." data-position='top'>Better introductions for websites and features with a step-by-step guide for your projects.</p>
         <a class="btn btn-large btn-success" href="javascript:void(0);" onclick="javascript:introJs().start();">Show me how</a>
       </div>
-
       <hr>
 
       <div class="row-fluid marketing">
@@ -67,6 +66,8 @@
       <div class="footer">
         <p>&copy; <a href='http://usabli.ca/' target="_blank" title="usabli.ca group">usabli.ca</a> 2013 - A weekend project by <a href="http://afshinm.name/" target="_blank">Afshin Mehrabani</a></p>
       </div>
+
+      <div id="step1-text" style="display:none"><b>Hello all!</b> :) This project's called Intro.js.<div>This is a demonstration of how it works.</div></div>
 
     </div>
     <script type="text/javascript" src="../intro.js"></script>

--- a/intro.js
+++ b/intro.js
@@ -223,7 +223,7 @@
       //set current step to the label
       oldHelperNumberLayer.innerHTML = targetElement.getAttribute("data-step");
       //set current tooltip text
-      oldtooltipLayer.innerHTML = targetElement.getAttribute("data-intro");
+      oldtooltipLayer.innerHTML = _getToolTipContent(targetElement);
       var oldShowElement = document.querySelector(".introjs-showElement");
       oldShowElement.className = oldShowElement.className.replace(/introjs-[a-zA-Z]+/g, '').trim();
       _placeTooltip(targetElement, oldtooltipContainer, oldArrowLayer);
@@ -247,7 +247,7 @@
       tooltipLayer.className = "introjs-tooltip";
 
       helperNumberLayer.innerHTML = targetElement.getAttribute("data-step");
-      tooltipLayer.innerHTML = "<div class='introjs-tooltiptext'>" + targetElement.getAttribute("data-intro") + "</div><div class='introjs-tooltipbuttons'></div>";
+      tooltipLayer.innerHTML = "<div class='introjs-tooltiptext'>" + _getToolTipContent(targetElement) + "</div><div class='introjs-tooltipbuttons'></div>";
       helperLayer.appendChild(helperNumberLayer);
       tooltipLayer.appendChild(arrowLayer);
       helperLayer.appendChild(tooltipLayer);
@@ -419,6 +419,25 @@
     elementPosition.left = _x;
 
     return elementPosition;
+  }
+
+  /**
+   * Returns matching element contents or data-into value
+   * if not found
+   * @api private
+   * @method _getToolTipContent
+   * @param {Object} element
+   * @returns Element's data-intro attribute text or element with matching id
+   */
+  function _getToolTipContent(element) {
+    var dataIntroAttr = element.getAttribute("data-intro");
+    var originalContent = document.getElementById(dataIntroAttr);
+    if (originalContent) {
+      var introContent = originalContent.cloneNode(true);
+      introContent.style.visibility = 'visible'
+      return introContent.innerHTML;
+    }
+    return dataIntroAttr;
   }
 
   var introJs = function (targetElm) {


### PR DESCRIPTION
See example.html for working example.

Given the following:

```
<h1 data-step="1" data-intro="step1-text">Intro.Js</h1>

<div id="step1-text" style="display:none">
  <b>Hello all!</b> :) This project's called Intro.js.
  <div>This is a demonstration of how it works.</div>
</div>
```

The tooltip for step 1 will contain the contents of the step1-text div allowing for richer tooltip contents and separation of help text from original markup.
