### PR TITLE
current step is 0, exit the intro

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -127,6 +127,7 @@
    */
   function _previousStep() {
     if (this._currentStep == 0) {
+      _exitIntro.call(this, this._targetElement);
       return false;
     }
 


### PR DESCRIPTION
When current step 0, exit the intro. Because I felt it was more natural that behavior reason.
