### PR TITLE
Add overlayOpacity to options

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -33,7 +33,8 @@
       nextLabel: 'Next &rarr;',
       prevLabel: '&larr; Back',
       skipLabel: 'Skip',
-      tooltipPosition: 'bottom'
+      tooltipPosition: 'bottom',
+      overlayOpacity: .5
     };
   }
 
@@ -466,7 +467,7 @@
     };
 
     setTimeout(function() {
-      styleText += 'opacity: .5;';
+      styleText += 'opacity: ' + this._options.overlayOpacity + ';';
       overlayLayer.setAttribute('style', styleText);
     }, 10);
     return true;


### PR DESCRIPTION
I found myself not able to change the overlay opacity, as long as it's directly added to the element's CSS. Not able to change this value might be a problem for sites with dark color schemes.
