### PR TITLE
Option to dynamically set the tooltip and helper backgrounds to the color of the body background

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -268,12 +268,13 @@
 
       //hide the tooltip
       oldtooltipContainer.style.opacity = 0;
+      
+      //set new position to helper layer      
+      oldHelperLayer.style.width    = (elementPosition.width + 10)  + 'px';
+      oldHelperLayer.style.height   = (elementPosition.height + 10)  + 'px';
+      oldHelperLayer.style.top      = (elementPosition.top - 5)  + 'px';
+      oldHelperLayer.style.left     = (elementPosition.left - 5)  + 'px';
 
-      //set new position to helper layer
-      oldHelperLayer.setAttribute('style', 'width: ' + (elementPosition.width + 10)  + 'px; ' +
-                                           'height:' + (elementPosition.height + 10) + 'px; ' +
-                                           'top:'    + (elementPosition.top - 5)     + 'px;' +
-                                           'left: '  + (elementPosition.left - 5)    + 'px;');
       //remove old classes
       var oldShowElement = document.querySelector('.introjs-showElement');
       oldShowElement.className = oldShowElement.className.replace(/introjs-[a-zA-Z]+/g, '').replace(/^\s+|\s+$/g, '');
@@ -290,6 +291,7 @@
         _placeTooltip.call(self, targetElement, oldtooltipContainer, oldArrowLayer);
         //show the tooltip
         oldtooltipContainer.style.opacity = 1;
+
       }, 350);
 
     } else {
@@ -303,6 +305,16 @@
                                         'height:' + (elementPosition.height + 10) + 'px; ' +
                                         'top:'    + (elementPosition.top - 5)     + 'px;' +
                                         'left: '  + (elementPosition.left - 5)    + 'px;');
+      //Option to dynamically set the tooltip and helper backgrounds to the color of the body background
+      switch (this._options.bg_color) {
+        case 'body':
+          var bodyColor = $('body').css("background-color");
+          tooltipLayer.style.backgroundColor = bodyColor;
+          helperLayer.style.backgroundColor = bodyColor;
+          break;
+        default:
+          break;
+      }
 
       //add helper layer to target element
       this._targetElement.appendChild(helperLayer);


### PR DESCRIPTION
My site supports more than one styles and thus, statically setting the color for the
tooltip and helper was not working.

I added an option "bg_color" to dynamically set the background color of the two layers. 
I implemented this with a switch hoping to make the option expandable.
For now the only available value for the option is 'body' which sets the color
of the background for the two layers to the color of the body background.

example:
.setOption('bg_color', 'body')

Furthermore,
I discovered that when the position of the oldHelperLayer is updated, with setAttr :
helperLayer.setAttribute('style', 'width: ' + (elementPosition.width + 10)  + 'px; ' +
                                        'height:' + (elementPosition.height + 10) + 'px; ' +
                                        'top:'    + (elementPosition.top - 5)     + 'px;' +
                                        'left: '  + (elementPosition.left - 5)    + 'px;');

all the other style options for the element get reset.

For this, I changed the position updating to :
oldHelperLayer.style.width    = (elementPosition.width + 10)  + 'px';
oldHelperLayer.style.height   = (elementPosition.height + 10)  + 'px';
oldHelperLayer.style.top      = (elementPosition.top - 5)  + 'px';
oldHelperLayer.style.left     = (elementPosition.left - 5)  + 'px';

instead of repeating the bg_colot option check after updating the position.

I hope this helps,
first pull request, be gentle!
