### PR TITLE
Separate content + HTML

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -67,22 +67,35 @@
       }
 
     } else {
-      //use steps from data-* annotations
+      //use steps from the list #tourContent 
 
-      var allIntroSteps = targetElm.querySelectorAll('*[data-intro]');
+      var allIntroSteps = targetElm.querySelectorAll('#tourContent > li');
       //if there's no element to intro
       if (allIntroSteps.length < 1) {
         return false;
       }
 
+      var cont = 1;
       for (var i = 0, elmsLength = allIntroSteps.length; i < elmsLength; i++) {
         var currentElement = allIntroSteps[i];
+
+        var currentId = currentElement.getAttribute("data-id");
+        var currentClass = currentElement.getAttribute("data-class");
+
+        if(currentId && currentId!= 'undefined'){
+            var currentDiv = document.getElementById(currentId);
+        }else{
+            var currentDiv = $('.'+currentClass).get(0);  // WARNING use of jQuery
+        }
+
+
         introItems.push({
-          element: currentElement,
-          intro: currentElement.getAttribute('data-intro'),
-          step: parseInt(currentElement.getAttribute('data-step'), 10),
-          position: currentElement.getAttribute('data-position') || this._options.tooltipPosition
+          element: currentDiv,
+          intro: currentElement.innerHTML,
+          step: cont,
+          position: currentElement.getAttribute("data-position")
         });
+        cont++;
       }
     }
 


### PR DESCRIPTION
I have made use of jQuery as I am using it in my application, but I'm sure you can do it with pure JavaScript.

I have managed to insert HTML in the tour popups as well as completely separate the tour content from the page layout.
`data-intro` attributes are no longer needed. Instead, a list containing information about the elements to take part in the tour and its text is needed as well as the floating box position.

`data-step` is not either needed. It will follow the list elements order.
