### PR TITLE
bug fix for IE8 without z-index and overlayLayer's onExit when onClick i...

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -532,7 +532,6 @@
       return '0';
     }
     //Prevent exception in IE
-	
     if(propValue.toLowerCase) {
       return propValue.toLowerCase();
     } else {
@@ -607,13 +606,14 @@
     targetElm.appendChild(overlayLayer);
 
     overlayLayer.onclick = function() {
-      if(self._options.exitOnOverlayClick == true) {
-        //check if any callback is defined
-        if (self._introExitCallback != undefined) {
-          self._introExitCallback.call(self);
-        }
-        _exitIntro.call(self, targetElm);
+      if(!self._options.exitOnOverlayClick) {
+        return;
       }
+      //check if any callback is defined
+      if (self._introExitCallback != undefined) {
+        self._introExitCallback.call(self);
+      }
+      _exitIntro.call(self, targetElm);
     };
 
     setTimeout(function() {


### PR DESCRIPTION
Hello. Thanks for such a great javascripts!
I found some bugs so send a fix request.
1. when 'exitOnOverlayClick:false' and set 'onexit' callback, every time clicking overlay layer causes unnecessary onexit callback.
2. when IE8, some conditions returns 'z-index' propValue as undefined, and toLowerCase method results in like null pointer exceptions.

please check it.
