### PR TITLE
Silently ignore missing steps in programmatic mode

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -63,7 +63,7 @@
         currentItem.step = i + 1;
         //grab the element with given selector from the page
         currentItem.element = document.querySelector(currentItem.element);
-        introItems.push(currentItem);
+        if (currentItem.element) introItems.push(currentItem);
       }
 
     } else {


### PR DESCRIPTION
If you specify a selector that does not exist, you get the dimmed page but no message. I have a project where the user can configure the content of the page themselves (optional portlets). But I have to define the tour up front, so need a way to ignore tour steps where the selector does not exist in the html. 

This one line change silently ignores steps where the selector does not exist

Thanks for the fantastic tool btw. So easy to use.
