### PR TITLE
Can't start the same intro.js object twice

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -62,7 +62,7 @@
         //set the step
         currentItem.step = i + 1;
         //grab the element with given selector from the page
-        currentItem.element = document.querySelector(currentItem.element);
+        currentItem.element = document.querySelector(currentItem.selector);
         introItems.push(currentItem);
       }
 


### PR DESCRIPTION
The culprit is line 65:

`currentItem.element = document.querySelector(currentItem.element);`

The element selector is overwritten with the actual DOM element. So the next time #start() is called on the same intro.js object, the query selector crashes.

The simplest solution would be to rename 'element' to 'selector':
`currentItem.element = document.querySelector(currentItem.selector);`

The downside is that it breaks the programatic API.
