### PR TITLE
Pass step options through to onchange and onbeforechange callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ introJs().onexit(function() {
 ###introJs.onchange(providedCallback)
 
 Set callback to change of each step of introduction. Given callback function will be called after completing each step.
-The callback function receives the element of the new step as an argument.
+The callback function receives the element of the new step as an argument, and also the original step options (this will allow you to pass additional data through to the callback). 
 
 **Available since:** v0.3.0
 
@@ -221,8 +221,9 @@ The callback function receives the element of the new step as an argument.
 
 **Example:**
 ```javascript
-introJs().onchange(function(targetElement) {  
+introJs().onchange(function(targetElement, options) { // options since v0.5.1
   alert("new step");
+  console.log(options);
 });
 ````
 
@@ -230,7 +231,7 @@ introJs().onchange(function(targetElement) {
 
 ###introJs.onbeforechange(providedCallback)
 
-Given callback function will be called before starting a new step of introduction. The callback function receives the element of the new step as an argument.
+Given callback function will be called before starting a new step of introduction. The callback function receives the element of the new step as an argument, and also the original step options (this will allow you to pass additional data through to the callback). 
 
 **Available since:** v0.4.0
 
@@ -242,8 +243,9 @@ Given callback function will be called before starting a new step of introductio
 
 **Example:**
 ```javascript
-introJs().onbeforechange(function(targetElement) {  
+introJs().onbeforechange(function(targetElement, options) { // options since v0.5.1
   alert("before new step");
+  console.log(options);
 });
 ````
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "intro.js",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A better way for new feature introduction and step-by-step users guide for your website and project.",
   "keywords": ["demo", "intro", "introduction"],
   "homepage": "http://usablica.github.com/intro.js/",

--- a/example/events/index.html
+++ b/example/events/index.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Defining with JSON configuration</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Intro.js - Better introductions for websites and features with a step-by-step guide for your projects.">
+    <meta name="author" content="Afshin Mehrabani (@afshinmeh) in usabli.ca group">
+
+    <!-- styles -->
+    <link href="../assets/css/bootstrap.min.css" rel="stylesheet">
+    <link href="../assets/css/demo.css" rel="stylesheet">
+
+    <!-- Add IntroJs styles -->
+    <link href="../../introjs.css" rel="stylesheet">
+
+    <link href="../assets/css/bootstrap-responsive.min.css" rel="stylesheet">
+  </head>
+
+  <body>
+
+    <div class="container-narrow">
+
+      <div class="masthead">
+        <ul id="step5" class="nav nav-pills pull-right">
+          <li><a href="https://github.com/usablica/intro.js/tags"><i class='icon-black icon-download-alt'></i> Download</a></li>
+          <li><a href="https://github.com/usablica/intro.js">Github</a></li>
+          <li><a href="https://twitter.com/usablica">@usablica</a></li>
+        </ul>
+        <h3 class="muted">Intro.js</h3>
+      </div>
+
+      <hr>
+
+      <div class="jumbotron">
+        <h1 id="step1">Events</h1>
+        <p id="step4" class="lead">In this example we are going to show how events can be used with intro.js</p>
+        <a class="btn btn-large btn-success" href="javascript:void(0);" onclick="startIntro();">Show me how</a>
+      </div>
+
+      <hr>
+
+      <div class="row-fluid marketing">
+        <div id="step2" class="span6">
+          <h4>Section One</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+          <h4>Section Two</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+          <h4>Section Three</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+        </div>
+
+        <div id="step3" class="span6">
+          <h4>Section Four</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+
+          <h4>Section Five</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+          <h4>Section Six</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+        </div>
+      </div>
+
+      <hr>
+
+    </div>
+    <script type="text/javascript" src="../../intro.js"></script>
+    <script type="text/javascript">
+      function startIntro(){
+        var intro = introJs();
+      
+          intro.oncomplete(function() {
+            alert("end of introduction");
+          });
+          
+          intro.onexit(function() {
+            alert("exited introduction");
+          });
+            
+          intro.onchange(function(targetElement, options) {
+            if (options.alertMe !== undefined) {
+              alert(options.alertMe);
+            }
+          });
+		
+          intro.setOptions({
+            steps: [
+              {
+                element: document.querySelector('#step1'),
+                intro: "This is a tooltip."
+              },
+              {
+                element: document.querySelectorAll('#step2')[0],
+                intro: "Ok, wasn't that fun?",
+                position: 'right',
+                alertMe: "You made it to step 2!"
+              },
+              {
+                element: '#step3',
+                intro: 'More features, more fun.',
+                position: 'left'
+              },
+              {
+                element: '#step4',
+                intro: "Another step.",
+                position: 'bottom',
+                alertMe: "You made it to step 4!"
+              },
+              {
+                element: '#step5',
+                intro: 'Get it, use it.'
+              }
+            ]
+          });
+
+          intro.start();
+      }
+    </script>
+  </body>
+</html>

--- a/example/index.html
+++ b/example/index.html
@@ -27,6 +27,7 @@
         <li><a href="RTL/index.html" title='RTL version'>RTL version</a></li>
         <li><a href="html-tooltip/index.html" title='HTML in tooltip'>HTML in tooltip</a></li>
         <li><a href="custom-class/index.html" title='Custom CSS Class'>Custom CSS Class</a></li>
+        <li><a href="events/index.html" title='Events'>Events</a></li>
       </ul>
     </div>
   </body>

--- a/intro.js
+++ b/intro.js
@@ -1,5 +1,5 @@
 /**
- * Intro.js v0.5.0
+ * Intro.js v0.5.1
  * https://github.com/usablica/intro.js
  * MIT licensed
  *
@@ -19,7 +19,7 @@
   }
 } (this, function (exports) {
   //Default config/variables
-  var VERSION = '0.5.0';
+  var VERSION = '0.5.1';
 
   /**
    * IntroJs main class
@@ -195,7 +195,7 @@
 
     var nextStep = this._introItems[this._currentStep];
     if (typeof (this._introBeforeChangeCallback) !== 'undefined') {
-      this._introBeforeChangeCallback.call(this, nextStep.element);
+      this._introBeforeChangeCallback.call(this, nextStep.element, nextStep);
     }
 
     _showElement.call(this, nextStep);
@@ -214,7 +214,7 @@
 
     var nextStep = this._introItems[--this._currentStep];
     if (typeof (this._introBeforeChangeCallback) !== 'undefined') {
-      this._introBeforeChangeCallback.call(this, nextStep.element);
+      this._introBeforeChangeCallback.call(this, nextStep.element, nextStep);
     }
 
     _showElement.call(this, nextStep);
@@ -355,7 +355,7 @@
   function _showElement(targetElement) {
 
     if (typeof (this._introChangeCallback) !== 'undefined') {
-        this._introChangeCallback.call(this, targetElement.element);
+        this._introChangeCallback.call(this, targetElement.element, targetElement);
     }
 
     var self = this,


### PR DESCRIPTION
Needed to be able to pass through some data from the initial step options json to use in the `onchange` / `onbeforechange` callbacks.

I added the `options` argument after the `targetElement` argument rather than replacing it outright to maintain backwards compatability, and also update the docs and version number for these changes (to make it clear that older versions will not have access to the options argument)
