### PR TITLE
Adds the "none" position to prevent showing the tooltip.

### DIFF
--- a/example/hello-world/index.html
+++ b/example/hello-world/index.html
@@ -41,7 +41,7 @@
       <hr>
 
       <div class="row-fluid marketing">
-        <div class="span6" data-step="2" data-intro="Ok, wasn't that fun?" data-position='right'>
+        <div class="span6" data-step="2" data-intro="Ok, wasn't that fun?" data-position='none'>
           <h4>Section One</h4>
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
 
@@ -52,7 +52,7 @@
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
           </div>
 
-        <div class="span6" data-step="3" data-intro="More features, more fun."  data-position='left'>
+        <div class="span6" data-step="3" data-intro="More features, more fun."  data-position='none'>
           <h4>Section Four</h4>
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
 

--- a/intro.js
+++ b/intro.js
@@ -280,6 +280,7 @@
     tooltipLayer.style.right   = null;
     tooltipLayer.style.bottom  = null;
     tooltipLayer.style.left    = null;
+    tooltipLayer.style.display = null;
 
     //prevent error when `this._currentStep` is undefined
     if(!this._introItems[this._currentStep]) return;
@@ -314,6 +315,9 @@
         tooltipLayer.style.top = '15px';
         tooltipLayer.style.right = (_getOffset(targetElement).width + 20) + 'px';
         arrowLayer.className = 'introjs-arrow right';
+        break;
+      case 'none':
+        tooltipLayer.style.display = 'none';
         break;
       case 'bottom':
       // Bottom going to follow the default behavior


### PR DESCRIPTION
In some use cases the tooltip may not be needed. For example, when wanted to show different parts of text in a webpage.

As there is no tooltip to advance from one frame to the next, clicking anywhere in the currently highlighted div will trigger the next action.

I'm creating this PR in case you happen to find useful the feature.
