### PR TITLE
Updated readme instructions for  SetOptions to use single quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Set a group of options to the introJs object.
 
 **Example:**
 ```javascript
-introJs().setOptions({ skipLabel: "Exit", tooltipPosition: "right" });
+introJs().setOptions({ 'skipLabel': 'Exit', 'tooltipPosition': 'right' });
 ````
 
 ----


### PR DESCRIPTION
The readme didn't specifically have single quotes around the option and its value.  So it never worked.  I updated the readme so that others won't have this problem
