### PR TITLE
Skip hidden elements

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -94,7 +94,7 @@
         var currentElement = allIntroSteps[i];
         if(currentElement.style.display == 'none')
         {
-        	continue
+        	continue;
         };
         introItems.push({
           element: currentElement,

--- a/intro.js
+++ b/intro.js
@@ -92,6 +92,10 @@
 
       for (var i = 0, elmsLength = allIntroSteps.length; i < elmsLength; i++) {
         var currentElement = allIntroSteps[i];
+        if(currentElement.style.display == 'none')
+        {
+        	continue
+        };
         introItems.push({
           element: currentElement,
           intro: currentElement.getAttribute('data-intro'),

--- a/intro.js
+++ b/intro.js
@@ -92,10 +92,9 @@
 
       for (var i = 0, elmsLength = allIntroSteps.length; i < elmsLength; i++) {
         var currentElement = allIntroSteps[i];
-        if(currentElement.style.display == 'none')
-        {
+        if (currentElement.style.display == 'none') {
         	continue;
-        };
+        }
         introItems.push({
           element: currentElement,
           intro: currentElement.getAttribute('data-intro'),


### PR DESCRIPTION
Currently if the element is hidden, intro.js will still show the help but at top/left corner. Usually we hide/show elements depending on what part of screen they are in and also depending on their security creds. 

So this is a serious issue since the help text cannot be shown to people without creds.