### PR TITLE
Added support for omitting data-step

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -92,12 +92,12 @@
 
       for (var i = 0, elmsLength = allIntroSteps.length; i < elmsLength; i++) {
         var currentElement = allIntroSteps[i];
-        var step=parseInt(currentElement.getAttribute('data-step'), 10);
+        var step = parseInt(currentElement.getAttribute('data-step'), 10);
         introItems.push({
           element: currentElement,
           intro: currentElement.getAttribute('data-intro'),
           //if step==NaN set step to 100
-          step: step?step:100,
+          step: step ? step : 100,
 	  tooltipClass: currentElement.getAttribute('data-tooltipClass'),
           position: currentElement.getAttribute('data-position') || this._options.tooltipPosition
         });


### PR DESCRIPTION
You may now add some elements with data-steps and some without.. The feature is that they elements are ordered as you expect. 
### Before

``` html
<div data-intro="This is shown first"></div>
<div data-intro="second..."></div>
<div data-intro="This is shown last" data-step="1"></div>
```
### With this feature

``` html
<div data-intro="second..."></div>
<div data-intro="This is shown last"></div>
<div data-intro="This is shown first" data-step="1"></div>
```
