### PR TITLE
Fixed scroll issue when scrolling down to elements bigger than window

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -535,14 +535,15 @@
 
     if (!_elementInViewport(targetElement.element)) {
       var rect = targetElement.element.getBoundingClientRect(),
-          top = rect.bottom - (rect.bottom - rect.top),
-          bottom = rect.bottom - _getWinSize().height;
+        winHeight=_getWinSize().height,
+        top = rect.bottom - (rect.bottom - rect.top),
+        bottom = rect.bottom - winHeight;
 
       // Scroll up
-      if (top < 0) {
+      if (top < 0 || targetElement.element.clientHeight > winHeight) {
         window.scrollBy(0, top - 30); // 30px padding from edge to look nice
 
-      // Scroll down
+        // Scroll down
       } else {
         window.scrollBy(0, bottom + 100); // 70px + 30px padding from edge to look nice
       }


### PR DESCRIPTION
When scrolling down to element that are bigger than the screen, it will scroll down to the bottom of that element. That leads to that you don't see the tooltip. This PR solves that issue by checking the size of the element and compares it with the window. 
