### PR TITLE
Turning off layer numbers

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -464,7 +464,7 @@
                                '</div><div class="introjs-tooltipbuttons"></div>';
 
       //add helper layer number
-      if (this._options.showStepNumbers) {
+      if (this._options.showStepNumbers == true) {
         var helperNumberLayer = document.createElement('span');
         helperNumberLayer.className = 'introjs-helperNumberLayer';
         helperNumberLayer.innerHTML = targetElement.step;


### PR DESCRIPTION
Turning off layered numbers was not working for me (at least in Chrome version 30.0.1599.101). The problem was that the statements for setting the "showStepNumbers" option would always execute, even when its value was set to "false".  
Setting the conditional if statement to be compared with the "true" value explicitly fixed the problem. So:

```
  //add helper layer number
  if (this._options.showStepNumbers == true) {
      ...
  }
```
