### PR TITLE
added onafterchange handler, and call it just before the end of _showElem...

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -635,6 +635,10 @@
         window.scrollBy(0, bottom + 100); // 70px + 30px padding from edge to look nice
       }
     }
+    
+    if (typeof (this._introAfterChangeCallback) !== 'undefined') {
+        this._introAfterChangeCallback.call(this, targetElement.element);
+    }
   }
 
   /**
@@ -864,6 +868,14 @@
         this._introChangeCallback = providedCallback;
       } else {
         throw new Error('Provided callback for onchange was not a function.');
+      }
+      return this;
+    },
+    onafterchange: function(providedCallback) {
+      if (typeof (providedCallback) === 'function') {
+        this._introAfterChangeCallback = providedCallback;
+      } else {
+        throw new Error('Provided callback for onafterchange was not a function');
       }
       return this;
     },


### PR DESCRIPTION
...ent method

difference with onchange is that onchange is executed first time upon entering _showElement method. This will fail if we want to, for example, set focus to the current input element being shown, because the element is modified in _showElement method. onafterchange is executed just before the end of _showElement method, so any changes to the current element will persist. I found this especially useful when trying to set focus to an input element which is currently being intro-ed using jquery's .focus().
