### PR TITLE
Bad sizing with Bootstrap 3

### DIFF
--- a/introjs.css
+++ b/introjs.css
@@ -48,6 +48,16 @@
           transition: all 0.3s ease-out;
 }
 
+.introjs-helperLayer *,
+.introjs-helperLayer *:before,
+.introjs-helperLayer *:after {
+  -webkit-box-sizing: content-box;
+     -moz-box-sizing: content-box;
+      -ms-box-sizing: content-box;
+       -o-box-sizing: content-box;
+          box-sizing: content-box;
+}
+
 .introjs-helperNumberLayer {
   position: absolute;
   top: -16px;


### PR DESCRIPTION
Bootstrap 3 resets the box-sizing CSS property so the Intro.js layout is broken.
