### PR TITLE
Fix crash after start in IE8

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -215,7 +215,7 @@
    * @method _cloneObject
   */
   function _cloneObject(object) {
-      if (object == null || typeof (object) != 'object' || object.hasOwnProperty("nodeName") === true || typeof (object.nodeType) != 'undefined') {
+      if (object == null || typeof (object) != 'object' || Object.prototype.hasOwnProperty.call(object, "nodeName") === true || typeof (object.nodeType) != 'undefined') {
           return object;
       }
       var temp = {};


### PR DESCRIPTION
hasOwnProperty is not supported on host objects for Internet Explorer 8 and below. So instead I use  Object.prototype.hasOwnProperty.call()
