### PR TITLE
bugfix: Wrong bullet highlighted

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -594,7 +594,7 @@
           self.goToStep(this.getAttribute('data-stepnumber'));
         };
 
-        if (i === 0) anchorLink.className = "active";
+        if (i === (targetElement.step-1)) anchorLink.className = "active";
 
         anchorLink.href = 'javascript:void(0);';
         anchorLink.innerHTML = "&nbsp;";


### PR DESCRIPTION
When starting introJs at a step != 0 the active bullet was not set correctly (always the first bullet gets active).
