### PR TITLE
Check for defined var before setting style

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -554,7 +554,7 @@
 
         //show the tooltip
         oldtooltipContainer.style.opacity = 1;
-        oldHelperNumberLayer.style.opacity = 1;
+        if (oldHelperNumberLayer) oldHelperNumberLayer.style.opacity = 1;
       }, 350);
 
     } else {


### PR DESCRIPTION
This is to stop an error from occurring when showStepNumbers is false.
