### PR TITLE
Fixing highlighting of table rows

### DIFF
--- a/introjs.css
+++ b/introjs.css
@@ -24,11 +24,15 @@
   opacity: 1.0 !important;
 }
 
-.introjs-showElement {
+.introjs-showElement,
+tr.introjs-showElement > td,
+tr.introjs-showElement > th {
   z-index: 9999999 !important;
 }
 
-.introjs-relativePosition {
+.introjs-relativePosition,
+tr.introjs-showElement > td,
+tr.introjs-showElement > th {
   position: relative;
 }
 


### PR DESCRIPTION
This fix adds the styles of `.introjs-showElement` to any `td` or `th` that are direct children of the highlighted element, if it's a table row.
