### PR TITLE
Invisible tooltip text and javascript crash

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -31,9 +31,9 @@
 
     this._options = {
       /* Next button label in tooltip box */
-      nextLabel: 'Next &rarr;',
+      nextLabel: 'Next →',
       /* Previous button label in tooltip box */
-      prevLabel: '&larr; Back',
+      prevLabel: '← Back',
       /* Skip button label in tooltip box */
       skipLabel: 'Skip',
       /* Done button label in tooltip box */
@@ -617,7 +617,7 @@
         if (i === 0) anchorLink.className = "active";
 
         anchorLink.href = 'javascript:void(0);';
-        anchorLink.innerHTML = "&nbsp;";
+        anchorLink.innerHTML = " ";
         anchorLink.setAttribute('data-stepnumber', this._introItems[i].step);
 
         innerLi.appendChild(anchorLink);

--- a/introjs.css
+++ b/introjs.css
@@ -138,6 +138,7 @@ tr.introjs-showElement > th {
   position: absolute;
   padding: 10px;
   background-color: white;
+  color: black;
   min-width: 200px;
   max-width: 300px;
   border-radius: 3px;


### PR DESCRIPTION
1. The HTML entities are causing Javascript to crash when combined with XHTML. When using unicode I don't really see the point of using entities anyways, so replaced them with the actual characters
2. My page is light text on dark background. Intro.js tooltip background was set to white, but no text color was defined, so the text ended up being invisible. Defined the tooltip color as black so it is sure to be contrast to the white.
