### PR TITLE
Do not overscroll the top of long elements

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -747,7 +747,7 @@
       var rect = targetElement.element.getBoundingClientRect(),
         winHeight=_getWinSize().height,
         top = rect.bottom - (rect.bottom - rect.top),
-        bottom = rect.bottom - winHeight;
+        bottom = Math.min(rect.bottom - winHeight, rect.top - 130); // do not overscroll the top + 30px padding
 
       //Scroll up
       if (top < 0 || targetElement.element.clientHeight > winHeight) {


### PR DESCRIPTION
It seems to be when scrolling we want the top of the element to be visible. But in case the top is already visible but not the bottom, it can happen that the page is scrolled to the bottom of the element over the top and hiding it.
