### PR TITLE
Fix for https://github.com/usablica/intro.js/issues/64 based on using pseudo elements

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -559,10 +559,6 @@
         clearTimeout(self._lastShowElementTimer);
       }
       self._lastShowElementTimer = setTimeout(function() {
-        //set current step to the label
-        if (oldHelperNumberLayer != null) {
-          oldHelperNumberLayer.innerHTML = targetElement.step;
-        }
         //set current tooltip text
         oldtooltipLayer.innerHTML = targetElement.intro;
         //set the tooltip position
@@ -639,7 +635,6 @@
       if (this._options.showStepNumbers == true) {
         var helperNumberLayer = document.createElement('span');
         helperNumberLayer.className = 'introjs-helperNumberLayer';
-        helperNumberLayer.innerHTML = targetElement.step;
         helperLayer.appendChild(helperNumberLayer);
       }
       tooltipLayer.appendChild(arrowLayer);

--- a/introjs.css
+++ b/introjs.css
@@ -58,10 +58,11 @@ tr.introjs-showElement > th {
           transition: all 0.3s ease-out;
 }
 
-.introjs-helperNumberLayer {
+.introjs-showElement:before {
+  content: attr(data-step);
   position: absolute;
-  top: -16px;
-  left: -16px;
+  left: -20px;
+  top: -21px;
   z-index: 9999999999 !important;
   padding: 2px;
   font-family: Arial, verdana, tahoma;


### PR DESCRIPTION
Hi,

Great library. I ran into issue 64 and noticed that your helper number is pure css. It seems that if the helper number is implemented as a css pseudo element then we can avoid the layering issues detailed in the issue.

I have only tested the basic examples but they seem fine. There may be other problems with my solution here that preclude them from being merged, but I'll create this pull request anyway so that other people may check it out and see if it works for them.

![Imgur](http://i.imgur.com/9Agd8jL.png)
