### PR TITLE
unify and fix position left and right handling

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -467,31 +467,24 @@
         arrowLayer.className = 'introjs-arrow bottom';
         break;
       case 'right':
-        tooltipLayer.style.left = (_getOffset(targetElement).width + 20) + 'px';
-        if (targetOffset.top + tooltipHeight > windowSize.height) {
-          // In this case, right would have fallen below the bottom of the screen.
-          // Modify so that the bottom of the tooltip connects with the target
-          arrowLayer.className = "introjs-arrow left-bottom";
-          tooltipLayer.style.top = "-" + (tooltipHeight - targetOffset.height - 20) + "px"
-        }
-        arrowLayer.className = 'introjs-arrow left';
-        break;
+        var position = 'left';
       case 'left':
+        if( typeof(position) == 'undefined') var position = 'right';
+
         if (this._options.showStepNumbers == true) {
           tooltipLayer.style.top = '15px';
         }
 
         if (targetOffset.top + tooltipHeight > windowSize.height) {
-          // In this case, left would have fallen below the bottom of the screen.
+          // In this case, tooltip would have fallen below the bottom of the screen.
           // Modify so that the bottom of the tooltip connects with the target
-          tooltipLayer.style.top = "-" + (tooltipHeight - targetOffset.height - 20) + "px"
-          arrowLayer.className = 'introjs-arrow right-bottom';
+          arrowLayer.className = "introjs-arrow "+position+"-bottom";
+          tooltipLayer.style.top = "-" + (tooltipHeight - targetOffset.height - 10) + "px"
         } else {
-          arrowLayer.className = 'introjs-arrow right';
+          arrowLayer.className = 'introjs-arrow '+position;
         }
-        tooltipLayer.style.right = (targetOffset.width + 20) + 'px';
 
-
+        tooltipLayer.style[position] = (_getOffset(targetElement).width + 20) + 'px';
         break;
       case 'floating':
         arrowLayer.style.display = 'none';


### PR DESCRIPTION
Afaik position `left` and `right` should do the same thing with the only difference is whether the tooltip is left or right of the element. Therefore I tried to unify the handling.

Besides this, there was a bug in position `right` if the element would have fallen below the screen because of a missing `else`.

I am **not** sure about those lines and why they are there:

```
if (this._options.showStepNumbers == true) {
  tooltipLayer.style.top = '15px';
}
```

They were only at position `left` before. I don't know why the step numbers should affect the top positioning of the tooltip, but maybe this has a purpose so I left it in.
