### PR TITLE
Added zero opacity background to disabled interaction element, fixes #362

### DIFF
--- a/introjs.css
+++ b/introjs.css
@@ -39,6 +39,10 @@ tr.introjs-showElement > th {
 .introjs-disableInteraction {
   z-index: 99999999 !important;
   position: absolute;
+  background-color: white;
+  opacity: 0;
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
+  filter: alpha(opacity=0);
 }
 
 .introjs-relativePosition,


### PR DESCRIPTION
Since initial value for background color being 'transparent' (if not mentioned). The elements beneath it can still be interacted with in IE, while they are covered in other browsers. As a fix, we can give background some color and set its opacity to zero, thus making it cover the underlying elements and prevent any interaction.
