### PR TITLE
Feature/element late binding

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -306,6 +306,9 @@
     }
 
     var nextStep = this._introItems[this._currentStep];
+    if (typeof nextStep.element === 'function') {
+      nextStep.element = nextStep.element();
+    }
     if (typeof (this._introBeforeChangeCallback) !== 'undefined') {
       this._introBeforeChangeCallback.call(this, nextStep.element);
     }
@@ -327,6 +330,9 @@
     }
 
     var nextStep = this._introItems[--this._currentStep];
+    if (typeof nextStep.element === 'function') {
+      nextStep.element = nextStep.element();
+    }
     if (typeof (this._introBeforeChangeCallback) !== 'undefined') {
       this._introBeforeChangeCallback.call(this, nextStep.element);
     }
@@ -667,7 +673,6 @@
    * @param {Object} targetElement
    */
   function _showElement(targetElement) {
-
     if (typeof (this._introChangeCallback) !== 'undefined') {
       this._introChangeCallback.call(this, targetElement.element);
     }

--- a/intro.js
+++ b/intro.js
@@ -484,6 +484,7 @@
     }
 
     tooltipLayer.className = ('introjs-tooltip ' + tooltipCssClass).replace(/^\s+|\s+$/g, '');
+    tooltipLayer.className = tooltipLayer.className.replace(' floating', '');
 
     //custom css class for tooltip boxes
     var tooltipCssClass = this._options.tooltipClass;
@@ -536,10 +537,9 @@
         //we have to adjust the top and left of layer manually for intro items without element
         tooltipOffset = _getOffset(tooltipLayer);
 
-        tooltipLayer.style.left   = '50%';
-        tooltipLayer.style.top    = '50%';
         tooltipLayer.style.marginLeft = '-' + (tooltipOffset.width / 2)  + 'px';
-        tooltipLayer.style.marginTop  = '-' + (tooltipOffset.height / 2) + 'px';
+        tooltipLayer.style.top = ((document.documentElement.clientHeight / 2) - tooltipOffset.height) + 'px';
+        tooltipLayer.className += ' floating';
 
         if (typeof(helperNumberLayer) != 'undefined' && helperNumberLayer != null) {
           helperNumberLayer.style.left = '-' + ((tooltipOffset.width / 2) + 18) + 'px';

--- a/intro.js
+++ b/intro.js
@@ -280,6 +280,23 @@
     }
   }
 
+  function _resolveElementAndShow(step) {
+    if (typeof step.element === 'function') {
+      step.element = step.element();
+    }
+
+    if (step.element) {
+      if (typeof (this._introBeforeChangeCallback) !== 'undefined') {
+        this._introBeforeChangeCallback.call(this, step.element);
+      }
+
+      _showElement.call(this, step);
+    }
+    else {
+      this.nextStep();
+    }
+  }
+
   /**
    * Go to next step on intro
    *
@@ -306,14 +323,7 @@
     }
 
     var nextStep = this._introItems[this._currentStep];
-    if (typeof nextStep.element === 'function') {
-      nextStep.element = nextStep.element();
-    }
-    if (typeof (this._introBeforeChangeCallback) !== 'undefined') {
-      this._introBeforeChangeCallback.call(this, nextStep.element);
-    }
-
-    _showElement.call(this, nextStep);
+    _resolveElementAndShow.call(this, nextStep);
   }
 
   /**
@@ -330,14 +340,7 @@
     }
 
     var nextStep = this._introItems[--this._currentStep];
-    if (typeof nextStep.element === 'function') {
-      nextStep.element = nextStep.element();
-    }
-    if (typeof (this._introBeforeChangeCallback) !== 'undefined') {
-      this._introBeforeChangeCallback.call(this, nextStep.element);
-    }
-
-    _showElement.call(this, nextStep);
+    _resolveElementAndShow.call(this, nextStep);
   }
 
   /**

--- a/intro.js
+++ b/intro.js
@@ -96,7 +96,7 @@
         }
 
         //intro without element
-        if (typeof(currentItem.element) === 'undefined' || currentItem.element == null) {
+        if (currentItem.element === undefined) {
           var floatingElementQuery = document.querySelector(".introjsFloatingElement");
 
           if (floatingElementQuery == null) {
@@ -251,20 +251,20 @@
     return false;
   }
 
- /*
+  /*
    * makes a copy of the object
    * @api private
    * @method _cloneObject
-  */
+   */
   function _cloneObject(object) {
-      if (object == null || typeof (object) != 'object' || typeof (object.nodeType) != 'undefined') {
-          return object;
-      }
-      var temp = {};
-      for (var key in object) {
-          temp[key] = _cloneObject(object[key]);
-      }
-      return temp;
+    if (object == null || typeof (object) != 'object' || typeof (object.nodeType) != 'undefined') {
+      return object;
+    }
+    var temp = {};
+    for (var key in object) {
+      temp[key] = _cloneObject(object[key]);
+    }
+    return temp;
   }
   /**
    * Go to specific step of introduction
@@ -287,8 +287,8 @@
             self._introBeforeChangeCallback.call(self, step.element);
           }
 
-        _showElement.call(self, step);
-      }
+          _showElement.call(self, step);
+        }
 
     if (typeof step.element === 'function') {
       step.selectorFunc = step.element;
@@ -303,14 +303,14 @@
       // support for promissory element functions
       if (step.element.then) {
         step.element.then(
-          function resolved(resolvedElement) {
+            function resolved(resolvedElement) {
               step.element = resolvedElement;
               show();
-          },
+            },
 
-          function failed() {
-            direction === 'forward' ? self.nextStep() : self.previousStep();
-          }
+            function failed() {
+              direction === 'forward' ? self.nextStep() : self.previousStep();
+            }
         );
       }
       else {
@@ -404,7 +404,7 @@
     var referenceLayer = targetElement.querySelector('.introjs-tooltipReferenceLayer');
     if (referenceLayer) {
       referenceLayer.parentNode.removeChild(referenceLayer);
-	}
+    }
     //remove disableInteractionLayer
     var disableInteractionLayer = targetElement.querySelector('.introjs-disableInteraction');
     if (disableInteractionLayer) {
@@ -672,9 +672,9 @@
 
       //set new position to helper layer
       helperLayer.setAttribute('style', 'width: ' + (elementPosition.width  + widthHeightPadding)  + 'px; ' +
-                                        'height:' + (elementPosition.height + widthHeightPadding)  + 'px; ' +
-                                        'top:'    + (elementPosition.top    - 5)   + 'px;' +
-                                        'left: '  + (elementPosition.left   - 5)   + 'px;');
+      'height:' + (elementPosition.height + widthHeightPadding)  + 'px; ' +
+      'top:'    + (elementPosition.top    - 5)   + 'px;' +
+      'left: '  + (elementPosition.left   - 5)   + 'px;');
 
     }
   }
@@ -996,15 +996,15 @@
 
     if (!_elementInViewport(targetElement.element) && this._options.scrollToElement === true) {
       var rect = targetElement.element.getBoundingClientRect(),
-        winHeight = _getWinSize().height,
-        top = rect.bottom - (rect.bottom - rect.top),
-        bottom = rect.bottom - winHeight;
+          winHeight = _getWinSize().height,
+          top = rect.bottom - (rect.bottom - rect.top),
+          bottom = rect.bottom - winHeight;
 
       //Scroll up
       if (top < 0 || targetElement.element.clientHeight > winHeight) {
         window.scrollBy(0, top - 30); // 30px padding from edge to look nice
 
-      //Scroll down
+        //Scroll down
       } else {
         window.scrollBy(0, bottom + 100); // 70px + 30px padding from edge to look nice
       }
@@ -1070,10 +1070,10 @@
     var rect = el.getBoundingClientRect();
 
     return (
-      rect.top >= 0 &&
-      rect.left >= 0 &&
-      (rect.bottom+80) <= window.innerHeight && // add 80 to get the text right
-      rect.right <= window.innerWidth
+    rect.top >= 0 &&
+    rect.left >= 0 &&
+    (rect.bottom+80) <= window.innerHeight && // add 80 to get the text right
+    rect.right <= window.innerWidth
     );
   }
 

--- a/intro.js
+++ b/intro.js
@@ -673,6 +673,7 @@
    * @param {Object} targetElement
    */
   function _showElement(targetElement) {
+
     if (typeof (this._introChangeCallback) !== 'undefined') {
       this._introChangeCallback.call(this, targetElement.element);
     }

--- a/introjs.css
+++ b/introjs.css
@@ -197,6 +197,10 @@ tr.introjs-showElement > th {
           transition: opacity 0.1s ease-out;
 }
 
+.introjs-tooltip.floating {
+  position: fixed;
+}
+
 .introjs-tooltipbuttons {
   text-align: right;
   white-space: nowrap;


### PR DESCRIPTION
This simple adjustment allows a function to be specified for an `element` property on a `step` object.  This allows for the element to be shown in the next/pending step to be evaluated as late as possible to account for dynamically rendered/added elements that are part of a tour.  

The default behavior of introjs seems to involve resolving all element selectors into `HTMLElement`s before the tour begins.  This doesn't work well with SPA and pages where elements are added after the DOM has loaded.

We are currently making use of this in an internal project, and this change appears to be necessary to properly include angular directives in the tour that contain contain elements that are conditionally rendered based on some async task result (ajax request, for example).

If there is anything that I can adjust here to make this more suitable (if it isn't suitable already), let me know.
