### PR TITLE
fixes #378 - bug( tooltip left offset calculation ) 

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -367,7 +367,7 @@
     var referenceLayer = targetElement.querySelector('.introjs-tooltipReferenceLayer');
     if (referenceLayer) {
       referenceLayer.parentNode.removeChild(referenceLayer);
-	}
+  }
     //remove disableInteractionLayer
     var disableInteractionLayer = targetElement.querySelector('.introjs-disableInteraction');
     if (disableInteractionLayer) {
@@ -529,7 +529,7 @@
       // Bottom going to follow the default behavior
       default:
         tooltipLayer.style.bottom = '-' + (_getOffset(tooltipLayer).height + 10) + 'px';
-        tooltipLayer.style.left = (_getOffset(targetElement).width / 2 - _getOffset(tooltipLayer).width / 2) + 'px';
+        tooltipLayer.style.left = Math.abs(_getOffset(targetElement).width / 2 - _getOffset(tooltipLayer).width / 2) + 'px';
 
         arrowLayer.className = 'introjs-arrow top';
         break;


### PR DESCRIPTION
fixes #378 
fixing when position is bottom and target element is thinner than tooltip.

![screenshot 2014-12-03 13 50 39](https://cloud.githubusercontent.com/assets/1738390/5287974/8c6f8702-7af6-11e4-9acd-5cea831112db.png)
