### PR TITLE
Fixes offset calculation for scrolled elements

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -1111,8 +1111,8 @@
     var _x = 0;
     var _y = 0;
     while (element && !isNaN(element.offsetLeft) && !isNaN(element.offsetTop)) {
-      _x += element.offsetLeft;
-      _y += element.offsetTop;
+      _x += element.offsetLeft - element.scrollLeft;
+      _y += element.offsetTop - element.scrollTop;
       element = element.offsetParent;
     }
     //set top


### PR DESCRIPTION
fixes Issue #93 
see updated answer @https://stackoverflow.com/questions/442404/retrieve-the-position-x-y-of-an-html-element/442474#442474

