### PR TITLE
Fix stage number positioning with bootstrap 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ Want to learn faster and easier? Here we have **Instant IntroJs**, Packt Publish
    - Fix bad sizing with Bootstrap 3
    - Add disable interaction ability
    - Fix code styling issues and many minor bug fixes
+   - Fix stage number positioning with bootstrap
 
  * **v0.9.0** - 2014-05-23
    - Add IntroJS templates

--- a/introjs.css
+++ b/introjs.css
@@ -76,7 +76,10 @@ tr.introjs-showElement > th {
 
 .introjs-helperLayer *,
 .introjs-helperLayer *:before,
-.introjs-helperLayer *:after {
+.introjs-helperLayer *:after,
+.introjs-tooltipReferenceLayer *,
+.introjs-tooltipReferenceLayer *:before,
+.introjs-tooltipReferenceLayer *:after {
   -webkit-box-sizing: content-box;
      -moz-box-sizing: content-box;
       -ms-box-sizing: content-box;


### PR DESCRIPTION
This is fix for using intro.js with bootstrap 3 and having stage number misplaced, issue has been described there[https://github.com/usablica/intro.js/issues/381]. (thanks to @Bonsanto)

This problem affects all layouts (not only introjs-nassim.css, as issue mentioned above may suggest).

Basically it's caused by bootstrap 3 policy for `box-sizing: border-box` everywhere. I've added `content-box` to `*`, and not only `introjs-helperNumberLayer`, because it affects more elements (`introjs-tooltip` f.ex.).
