### PR TITLE
correct top position on firefox

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -1108,17 +1108,17 @@
     elementPosition.height = element.offsetHeight;
 
     //calculate element top and left
-    var _x = 0;
+    /*var _x = 0;
     var _y = 0;
     while (element && !isNaN(element.offsetLeft) && !isNaN(element.offsetTop)) {
       _x += element.offsetLeft;
       _y += element.offsetTop;
       element = element.offsetParent;
-    }
+    }*/
     //set top
-    elementPosition.top = _y;
+    elementPosition.top = element.getBoundingClientRect().top;
     //set left
-    elementPosition.left = _x;
+    elementPosition.left = element.getBoundingClientRect().left;
 
     return elementPosition;
   }

--- a/introjs.css
+++ b/introjs.css
@@ -85,6 +85,7 @@ tr.introjs-showElement > th {
 }
 
 .introjs-helperNumberLayer {
+  box-sizing: initial;
   position: absolute;
   top: -16px;
   left: -16px;


### PR DESCRIPTION
Hi,

I've noticed that the top position don't work well on firefox on ubuntu. So I changed element.offsetTop to element.getBoundingClientRect().top .

https://developer.mozilla.org/en-US/docs/Web/API/element.getBoundingClientRect

I've tested on firefox and chromium and it's ok.
