### PR TITLE
Prevent tabbing behind overlay

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -418,7 +418,7 @@
       window.removeEventListener("focus", this._onFocus, true);
       window.removeEventListener('resize', self._onResize, true);
     } else if (document.detachEvent) { //IE
-      document.detachEvent('onkeypress', this._onKeyDown);
+      document.detachEvent('onkeydown', this._onKeyDown);
       document.detachEvent('onfocus', this._onFocus, true);
       document.detachEvent('onresize', self._onResize);
     }


### PR DESCRIPTION
This change prevents a user from focusing on elements behind the overlay.  It checks to see if the focused item  is within the helplayer container and if it is not, then it sets focus to the 'next' button.
