### PR TITLE
disableInteraction bugfix

### DIFF
--- a/introjs.css
+++ b/introjs.css
@@ -65,7 +65,7 @@ tr.introjs-showElement > th {
 
 .introjs-tooltipReferenceLayer {
   position: absolute;
-  z-index: 10000000;
+  z-index: 9999997;
   background-color: transparent;
   -webkit-transition: all 0.3s ease-out;
      -moz-transition: all 0.3s ease-out;


### PR DESCRIPTION
the disableInteraction seems always to be true. turned out there is an issue with the z-indexes. tooltipReferenceLayer has to be lower than helperLayer for it to work. disableInteraction option works correctly after this little fix.