### PR TITLE
only apply .introjs-arrow.left if the tooltip was not re-positioned

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -473,8 +473,9 @@
           // Modify so that the bottom of the tooltip connects with the target
           arrowLayer.className = "introjs-arrow left-bottom";
           tooltipLayer.style.top = "-" + (tooltipHeight - targetOffset.height - 20) + "px"
+        } else {
+          arrowLayer.className = 'introjs-arrow left';
         }
-        arrowLayer.className = 'introjs-arrow left';
         break;
       case 'left':
         if (this._options.showStepNumbers == true) {


### PR DESCRIPTION
When the tooltip falls below the window, we reposition it to push up
into the existing viewport. This fix also adds in the proper arrow
styling so that it falls on the bottom of this tooltip and points to
the actual content.