### PR TITLE
Update introjs.css

### DIFF
--- a/introjs.css
+++ b/introjs.css
@@ -77,7 +77,8 @@ tr.introjs-showElement > th {
 
 .introjs-helperLayer *,
 .introjs-helperLayer *:before,
-.introjs-helperLayer *:after {
+.introjs-helperLayer *:after,
+.introjs-helperNumberLayer {
   -webkit-box-sizing: content-box;
      -moz-box-sizing: content-box;
       -ms-box-sizing: content-box;
@@ -107,7 +108,6 @@ tr.introjs-showElement > th {
   background:         linear-gradient(to bottom, #ff3019 0%, #cf0404 100%);  /* W3C */
   width: 20px;
   height:20px;
-  box-sizing: content-box;
   line-height: 20px;
   border: 3px solid white;
   border-radius: 50%;

--- a/introjs.css
+++ b/introjs.css
@@ -107,6 +107,7 @@ tr.introjs-showElement > th {
   background:         linear-gradient(to bottom, #ff3019 0%, #cf0404 100%);  /* W3C */
   width: 20px;
   height:20px;
+  box-sizing: content-box;
   line-height: 20px;
   border: 3px solid white;
   border-radius: 50%;


### PR DESCRIPTION
Make sure the box-sizing of helper number layer is content-box.

Libraries like Bootstrap 3 set default `box-sizing: border-box` for most elements, which makes `introjs-helperNumberLayer` smaller.

Reference: [Why did Bootstrap 3 switch to box-sizing: border-box?](http://stackoverflow.com/questions/18854259/why-did-bootstrap-3-switch-to-box-sizing-border-box).
