### PR TITLE
Only align the tooltip on bottom if there is enough space above

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -479,7 +479,8 @@
         break;
       case 'right':
         tooltipLayer.style.left = (targetOffset.width + 20) + 'px';
-        if (targetOffset.top + tooltipOffset.height > windowSize.height) {
+        if (targetOffset.top + tooltipOffset.height > windowSize.height &&
+            tooltipOffset.height < targetOffset.top + targetOffset.height) {
           // In this case, right would have fallen below the bottom of the screen.
           // Modify so that the bottom of the tooltip connects with the target
           arrowLayer.className = "introjs-arrow left-bottom";
@@ -493,7 +494,8 @@
           tooltipLayer.style.top = '15px';
         }
 
-        if (targetOffset.top + tooltipOffset.height > windowSize.height) {
+        if (targetOffset.top + tooltipOffset.height > windowSize.height &&
+            tooltipOffset.height < targetOffset.top + targetOffset.height) {
           // In this case, left would have fallen below the bottom of the screen.
           // Modify so that the bottom of the tooltip connects with the target
           tooltipLayer.style.top = "-" + (tooltipOffset.height - targetOffset.height - 20) + "px";


### PR DESCRIPTION
This applies to position left and right.
If there tooltip is taller than the space left and aligned at the bottom,
it will vanish under the top edge of the viewport. So check if there is
enough space left above.

The issue can be seen here: http://jsfiddle.net/0x20urxg/2/
