### PR TITLE
Step number and tooltip positioning when the highlighted element is on the edge of the document

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -475,7 +475,7 @@
 
         var tooltipLayerStyleLeft = 15;
         _checkRight(targetOffset, tooltipLayerStyleLeft, tooltipOffset, windowSize, tooltipLayer);
-        tooltipLayer.style.bottom = (targetOffset.height +  20) + 'px';
+        tooltipLayer.style.bottom = (targetOffset.height + 20) + 'px';
         break;
       case 'right':
         tooltipLayer.style.left = (targetOffset.width + 20) + 'px';
@@ -496,7 +496,7 @@
         if (targetOffset.top + tooltipOffset.height > windowSize.height) {
           // In this case, left would have fallen below the bottom of the screen.
           // Modify so that the bottom of the tooltip connects with the target
-          tooltipLayer.style.top = "-" + (tooltipOffset.height - targetOffset.height - 20) + "px";
+          tooltipLayer.style.top = "-" + (tooltipOffset.height - targetOffset.height - 5) + "px";
           arrowLayer.className = 'introjs-arrow right-bottom';
         } else {
           arrowLayer.className = 'introjs-arrow right';
@@ -673,18 +673,53 @@
 
       var currentElement  = this._introItems[this._currentStep],
           elementPosition = _getOffset(currentElement.element),
-          widthHeightPadding = 10;
+          PADDING_AND_BORDER = 5 + 1;
 
       if (currentElement.position == 'floating') {
-        widthHeightPadding = 0;
+        helperLayer.classList.add("introjs-tooltipReferenceLayer--floating");
       }
+      else {
+        helperLayer.classList.remove("introjs-tooltipReferenceLayer--floating");
+      }
+      
+      _setHelperLayerClasses(helperLayer, elementPosition);
 
       //set new position to helper layer
-      helperLayer.setAttribute('style', 'width: ' + (elementPosition.width  + widthHeightPadding)  + 'px; ' +
-                                        'height:' + (elementPosition.height + widthHeightPadding)  + 'px; ' +
-                                        'top:'    + (elementPosition.top    - 5)   + 'px;' +
-                                        'left: '  + (elementPosition.left   - 5)   + 'px;');
+      helperLayer.setAttribute('style', 'width: ' + elementPosition.width  + 'px; ' +
+                                        'height:' + elementPosition.height + 'px; ' +
+                                        'top:'    + (elementPosition.top    - PADDING_AND_BORDER)   + 'px;' +
+                                        'left: '  + (elementPosition.left   - PADDING_AND_BORDER)   + 'px;');
 
+    }
+  }
+  
+  /**
+   * Update the helper layer classes depending on the element position on the screen
+   *
+   * @api private
+   * @method _setHelperLayerClasses
+   * @param {Object} helperLayer
+   * @param {Object} elementPosition
+   */
+  function _setHelperLayerClasses(helperLayer, elementPosition) {
+    var EDGE_TRESHOLD = 20;
+    
+    helperLayer.classList.remove("introjs-tooltipReferenceLayer--top", "introjs-tooltipReferenceLayer--bottom", "introjs-tooltipReferenceLayer--left", "introjs-tooltipReferenceLayer--right");
+    
+    // Check if the helper layer is positioned close to the top or the bottom of the document
+    if (elementPosition.top < EDGE_TRESHOLD) {
+      helperLayer.classList.add("introjs-tooltipReferenceLayer--top");
+    }
+    else if (document.documentElement.scrollHeight - (elementPosition.top + elementPosition.height) < EDGE_TRESHOLD) {
+      helperLayer.classList.add("introjs-tooltipReferenceLayer--bottom");
+    }
+    
+    // Check if the helper layer is positioned close to the left or the right edge of the document
+    if (elementPosition.left < EDGE_TRESHOLD) {
+      helperLayer.classList.add("introjs-tooltipReferenceLayer--left");
+    }
+    else if (document.documentElement.scrollWidth - (elementPosition.left + elementPosition.width) < EDGE_TRESHOLD) {
+      helperLayer.classList.add("introjs-tooltipReferenceLayer--right");
     }
   }
 

--- a/introjs.css
+++ b/introjs.css
@@ -48,6 +48,7 @@ tr.introjs-showElement > th {
 }
 
 .introjs-helperLayer {
+  padding: 5px;
   position: absolute;
   z-index: 9999998;
   background-color: #FFF;
@@ -64,6 +65,7 @@ tr.introjs-showElement > th {
 }
 
 .introjs-tooltipReferenceLayer {
+  padding: 5px;
   position: absolute;
   visibility: hidden;
   z-index: 10000000;
@@ -73,6 +75,20 @@ tr.introjs-showElement > th {
       -ms-transition: all 0.3s ease-out;
        -o-transition: all 0.3s ease-out;
           transition: all 0.3s ease-out;
+}
+
+.introjs-tooltipReferenceLayer--right {
+  padding-right: 0;
+  border-right: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.introjs-tooltipReferenceLayer--bottom {
+  padding-bottom: 0;
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .introjs-helperLayer *,
@@ -113,6 +129,16 @@ tr.introjs-showElement > th {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff3019', endColorstr='#cf0404', GradientType=0); /* IE6-9 */
   filter: progid:DXImageTransform.Microsoft.Shadow(direction=135, strength=2, color=ff0000); /* IE10 text shadows */
   box-shadow: 0 2px 5px rgba(0,0,0,.4);
+}
+
+.introjs-tooltipReferenceLayer--top .introjs-helperNumberLayer {
+  top: auto;
+  bottom: -16px;
+}
+
+.introjs-tooltipReferenceLayer--left .introjs-helperNumberLayer {
+  left: auto;
+  right: -16px;
 }
 
 .introjs-arrow {


### PR DESCRIPTION
Fixes step number and tooltip positioning in this kind of scenarios:
https://jsbin.com/dunigopazo/1/edit?html,output

When the highlighted element is next to the left edge, the number is moved to right corner and when the element is next to top edge, the number is moved to bottom corner.
Fixes also the highlight area positioning (especially in steps 4 and 5) and prevents the nasty scroll bars from showing in steps 3 and 5.
