### PR TITLE
Add "before" and "after" callbacks for steps in programmatic configuration

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -314,9 +314,18 @@
       return;
     }
 
+    // Notify previous step of change
+    var lastActiveStep = this._introItems[this._lastActiveStep || 0];
+    if (typeof (lastActiveStep) !== 'undefined' && typeof (lastActiveStep.after) !== 'undefined') {
+      lastActiveStep.after.call(this, lastActiveStep);
+    }
+
     var nextStep = this._introItems[this._currentStep];
     if (typeof (this._introBeforeChangeCallback) !== 'undefined') {
       this._introBeforeChangeCallback.call(this, nextStep.element);
+    }
+    if (typeof (nextStep.before) !== 'undefined') {
+      nextStep.before.call(this, nextStep);
     }
 
     _showElement.call(this, nextStep);
@@ -335,9 +344,18 @@
       return false;
     }
 
+    // Notify previous step of change
+    var lastActiveStep = this._introItems[this._lastActiveStep || 0];
+    if (typeof (lastActiveStep) !== 'undefined' && typeof (lastActiveStep.after) !== 'undefined') {
+      lastActiveStep.after.call(this, lastActiveStep);
+    }
+
     var nextStep = this._introItems[--this._currentStep];
     if (typeof (this._introBeforeChangeCallback) !== 'undefined') {
       this._introBeforeChangeCallback.call(this, nextStep.element);
+    }
+    if (typeof (nextStep.before) !== 'undefined') {
+      nextStep.before.call(this, nextStep);
     }
 
     _showElement.call(this, nextStep);
@@ -357,6 +375,12 @@
     //return if intro already completed or skipped
     if (overlayLayer == null) {
       return;
+    }
+
+    // Notify previous step of change
+    var lastActiveStep = this._introItems[this._lastActiveStep || 0];
+    if (typeof (lastActiveStep) !== 'undefined' && typeof (lastActiveStep.after) !== 'undefined') {
+      lastActiveStep.after.call(this, lastActiveStep);
     }
 
     //for fade-out animation
@@ -412,6 +436,7 @@
 
     //set the step to zero
     this._currentStep = undefined;
+    this._lastActiveStep = undefined;
   }
 
   /**
@@ -713,6 +738,8 @@
    * @param {Object} targetElement
    */
   function _showElement(targetElement) {
+
+    this._lastActiveStep = this._currentStep;
 
     if (typeof (this._introChangeCallback) !== 'undefined') {
       this._introChangeCallback.call(this, targetElement.element);


### PR DESCRIPTION
This PR adds a `before` and `after` callback function to the steps to make it easier to handle context dependent events when switching between steps using the programmatic configuration.
The `before` function will be triggered similarly to the `onbeforechange` event, but the step object is given to the object for more context information - additional context information from the step might be useful when handling events. The `after` function will NOT be triggered just after it is rendered as the `onafterchange` event does, but it will be triggered when the user moves to the next or exits the step. This will help to keep the logic clean for step-events.
To handle all this information, an additional property is set (`_lastActiveStep`) to keep track of the last shown step (and if any was shown previously).
