### PR TITLE
tooltipPosition option is not applied, when steps are defined in code

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -111,6 +111,10 @@
 
           currentItem.element  = floatingElementQuery;
           currentItem.position = 'floating';
+        } else {
+            // using default options, if not set
+            if (!currentItem.position)
+                currentItem.position = this._options.tooltipPosition;
         }
 
         if (currentItem.element != null) {


### PR DESCRIPTION
If tooltipPosition option is set, but the steps are added via setOptions (and no explicit option is defined), the tooltipOption is not applied
