### PR TITLE
Go to correct step when hitting enter while focussed on a step bullet

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -225,6 +225,9 @@
               self._introExitCallback.call(self);
             }
             _exitIntro.call(self, targetElm);
+          } else if (target && target.getAttribute('data-stepnumber')) {
+            //user hit enter while focusing on step bullet
+            target.click();
           } else {
             //default behavior for responding to enter
             _nextStep.call(self);


### PR DESCRIPTION
Currently, when a step bullet has focus and you hit the enter key, it will advance to the next step rather than going to the step that matches the step bullet that had focus.
