### PR TITLE
Moved all calls to _introExitCallback to one place in _exitIntro

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,11 @@ Github: https://github.com/Agnie-Software/gwt-introjs
 
 ## Build
 
-First you should install `nodejs` and `npm`, then first run this command: `npm install` to install all dependencies.
+First you should install `nodejs` and `npm`, and `make` then first run this command: `npm install` to install all dependencies.
+
+Note: Make requires the server jre, or you can bypass it as follows: http://stackoverflow.com/questions/18123144/missing-server-jvm-java-jre7-bin-server-jvm-dll
+
+Note: You may have to add `make` to your path.
 
 Now you can run this command to minify all static resources:
 

--- a/intro.js
+++ b/intro.js
@@ -198,10 +198,6 @@
       self._onKeyDown = function(e) {
         if (e.keyCode === 27 && self._options.exitOnEsc == true) {
           //escape key pressed, exit the intro
-          //check if exit callback is defined
-          if (self._introExitCallback != undefined) {
-            self._introExitCallback.call(self);
-          }
           _exitIntro.call(self, targetElm);
         } else if(e.keyCode === 37) {
           //left arrow
@@ -219,10 +215,6 @@
             //user hit enter while focusing on skip button
             if (self._introItems.length - 1 == self._currentStep && typeof (self._introCompleteCallback) === 'function') {
                 self._introCompleteCallback.call(self);
-            }
-            //check if any callback is defined
-            if (self._introExitCallback != undefined) {
-              self._introExitCallback.call(self);
             }
             _exitIntro.call(self, targetElm);
           } else {
@@ -417,6 +409,11 @@
 
     //set the step to zero
     this._currentStep = undefined;
+
+    //check if exit callback is defined
+    if (this._introExitCallback != undefined) {
+      this._introExitCallback.call(this);
+    }
   }
 
   /**
@@ -953,10 +950,6 @@
           self._introCompleteCallback.call(self);
         }
 
-        if (self._introItems.length - 1 != self._currentStep && typeof (self._introExitCallback) === 'function') {
-          self._introExitCallback.call(self);
-        }
-
         _exitIntro.call(self, self._targetElement);
       };
 
@@ -1164,11 +1157,6 @@
 
     overlayLayer.onclick = function() {
       if (self._options.exitOnOverlayClick == true) {
-
-        //check if any callback is defined
-        if (self._introExitCallback != undefined) {
-          self._introExitCallback.call(self);
-        }
         _exitIntro.call(self, targetElm);
       }
     };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "intro.js",
     "description": "Better introductions for websites and features with a step-by-step guide for your projects",
-    "version": "2.0",
+    "version": "2.0.1",
     "author": "Afshin Mehrabani <afshin.meh@gmail.com>",
     "repository": {
         "type": "git",


### PR DESCRIPTION
I moved all calls to _introExitCallback to one place at the very end of _exitIntro. So now, onexit, which is _introExitCallback, is always called when intro exits for any reason and it is all the way at the very end. The very last step, as it should be.

Also, I improved the build steps.
