### PR TITLE
Display floating tooltips in the center of the viewport even if the page has been scrolled.

### DIFF
--- a/introjs.css
+++ b/introjs.css
@@ -338,7 +338,7 @@ tr.introjs-showElement > th {
 }
 
 .introjsFloatingElement {
-  position: absolute;
+  position: fixed;
   height: 0;
   width: 0;
   left: 50%;


### PR DESCRIPTION
This fixes a bug that you can see on http://usablica.github.io/intro.js/example/withoutElement/index.html.

1. Resize your browser so that you have to scroll down to see Section Three and Section Six.
1. Scroll down a bit so that you can see Section Three and Section Six.
1. Click the "Show me how" button. The tooltip appears near the top of the page instead of in the middle.