### PR TITLE
Remove multiple overlay layers if present

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -356,21 +356,21 @@
    * @param {Object} targetElement
    */
   function _exitIntro(targetElement) {
-    //remove overlay layer from the page
-    var overlayLayer = targetElement.querySelector('.introjs-overlay');
+    //remove overlay layers from the page
+    var overlayLayers = targetElement.querySelectorAll('.introjs-overlay');
 
-    //return if intro already completed or skipped
-    if (overlayLayer == null) {
-      return;
+    if (overlayLayers && overlayLayers.length > 0) {
+      for (var i = overlayLayers.length - 1; i >= 0; i--) {
+        //for fade-out animation
+        var overlayLayer = overlayLayers[i];
+        overlayLayer.style.opacity = 0;
+        setTimeout(function () {
+          if (this.parentNode) {
+            this.parentNode.removeChild(this);
+          }
+        }.bind(overlayLayer), 500);
+      };
     }
-
-    //for fade-out animation
-    overlayLayer.style.opacity = 0;
-    setTimeout(function () {
-      if (overlayLayer.parentNode) {
-        overlayLayer.parentNode.removeChild(overlayLayer);
-      }
-    }, 500);
 
     //remove all helper layers
     var helperLayer = targetElement.querySelector('.introjs-helperLayer');


### PR DESCRIPTION
@afshinm, ideally there should be one _overlay_ layer present, but in cases when `introJs.exit()` is called and immediately `introJs().start()` is called, there as two _overlayLayer_ present in dom, so when `introJs.exit()` is called again, one _overlayLayer_ is removed and other tends to exist unless user clicks on it to remove it.

This fix will remove all the _overlayLayers_ present.
