### PR TITLE
Remove `introjs-fixedTooltip` if not needed

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -698,6 +698,8 @@
       // if the target element is fixed, the tooltip should be fixed as well.
       if (_isFixed(currentElement.element)) {
         helperLayer.className += ' introjs-fixedTooltip';
+      } else {
+        helperLayer.className = helperLayer.className.replace(' introjs-fixedTooltip', '');
       }
 
       if (currentElement.position == 'floating') {


### PR DESCRIPTION
Let's consider we got both a fixed and a not fixed elements (order matters) handled by intro.js on the same page. On Firefox, intro.js would first add the `introjs-fixedTooltip` on the helper layer. That's normal, as the first element is fixed. Yet, it won't remove this class on the second one, which is not fixed.

This PR fixes the issue.