### PR TITLE
Added support for promises in the beforeChange event, allows the user…

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -330,8 +330,16 @@
     }
 
     var nextStep = this._introItems[this._currentStep];
+    var beforeChangePromise = null;
     if (typeof (this._introBeforeChangeCallback) !== 'undefined') {
-      this._introBeforeChangeCallback.call(this, nextStep.element);
+      beforeChangePromise = this._introBeforeChangeCallback.call(this, nextStep.element);
+    }
+    if (beforeChangePromise && typeof beforeChangePromise === 'object' && typeof beforeChangePromise.then === 'function') {
+      var that = this;
+      beforeChangePromise.then(function () {
+        _showElement.call(that, nextStep);
+      });
+      return;
     }
 
     _showElement.call(this, nextStep);


### PR DESCRIPTION
… to perform asynchronous tasks before continuing with the next element.

Allows the user to delay (but not stop) the progression (for asynchronous tasks that must be executed prior to progressing) to the next element via promises. In order to utilize, the onbeforechange callback can return a Promise object that is resolved when the user wants to continue with the progression.