### PR TITLE
Intro.js with enhancements

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -11,6 +11,7 @@
  *   skipLabel
  *   doneLabel
  *   doneClass
+ *   doneClassInsteadOfDefault
  *   tooltipPosition
  *   tooltipClass
  *   highlightClass
@@ -89,8 +90,10 @@
       skipLabel: 'Skip',
       /* Done button label in tooltip box */
       doneLabel: 'Done',
-      /* Default tooltip box position */
+      /* Class to add on Done button */
       doneClass: null,
+      /* Should doneClass replace (rather than add to) default button class? Does not work well with showBackButton or showBullets. */
+      doneClassInsteadOfDefault: null,
       /* Default tooltip box position */
       tooltipPosition: 'bottom',
       /* Next CSS class for tooltip boxes */
@@ -133,6 +136,10 @@
       /* Height of header area at the top not to be covered by tooltip. */
       headerHeight: 0
     };
+    if (this._options.doneClassInsteadOfDefault === null) {
+      // Options that allow going backwards on a tour require keeping the default introjs-button class.
+      this._options.doneClassInsteadOfDefault = !(this._options.showButtons || this._options.showBullets);
+    }
   }
 
   /**
@@ -1082,7 +1089,11 @@
     } else if (this._introItems.length - 1 == this._currentStep || this._introItems.length == 1) {
       skipTooltipButton.innerHTML = this._options.doneLabel;
       if (this._options.doneClass != null) {
-        skipTooltipButton.className = 'introjs-button ' + this._options.doneClass;
+        if (this._options.doneClassInsteadOfDefault) {
+          skipTooltipButton.className = this._options.doneClass;
+        } else {
+          skipTooltipButton.className = 'introjs-button ' + this._options.doneClass;
+        }
       }
 
       if (this._options.showBackButton) {

--- a/intro.js
+++ b/intro.js
@@ -27,6 +27,7 @@
  *   scrollToElement
  *   overlayOpacity
  *   padding
+ *   scrollPadding
  *   positionPrecedence
  *   disableInteraction
  *   hintPosition
@@ -123,6 +124,8 @@
       overlayOpacity: 0.8,
       /* Pixels of highlighted padding around element */
       padding: 5,
+      /* Padding to add after scrolling when element is not in the viewport (in pixels) */		 +      /* Pixels of highlighted padding around element */
+      scrollPadding: 30,
       /* Precedence of positions, when auto is enabled */
       positionPrecedence: ["bottom", "top", "right", "left"],
       /* Disable an interaction with element? */
@@ -1144,11 +1147,11 @@
 
       //Scroll up
       if (top < this._options.headerHeight || targetElement.element.clientHeight > winHeight) {
-        window.scrollBy(0, top - this._options.headerHeight - 30); // 30px padding from edge to look nice
+        window.scrollBy(0, top - this._options.headerHeight - this._options.scrollPadding); // 30px padding from edge to look nice
 
       //Scroll down
       } else {
-        window.scrollBy(0, bottom + 100); // 70px + 30px padding from edge to look nice
+        window.scrollBy(0, bottom + 70 + this._options.scrollPadding); // 70px + 30px padding from edge to look nice
       }
     }
 
@@ -1657,7 +1660,7 @@
    */
   function _updateProgressBar(self, oldReferenceLayer) {
     if (self._monkeypatch && '_updateProgressBar' in self._monkeypatch) {
-    	self._monkeypatch._updateProgressBar(self, oldReferenceLayer);
+      self._monkeypatch._updateProgressBar(self, oldReferenceLayer);
     } else {
       oldReferenceLayer.querySelector('.introjs-progress .introjs-progressbar').setAttribute('style', 'width:' + _getProgress.call(self) + '%;');
     }

--- a/intro.js
+++ b/intro.js
@@ -43,7 +43,6 @@
  *   goToStep(step)
  *   nextStep()
  *   previousStep()
- *   updateStep()
  *   exit()
  *   refresh()
  *   onbeforechange(providedCallback)
@@ -1844,17 +1843,6 @@
     previousStep: function() {
       _previousStep.call(this);
       return this;
-    },
-    updateStep: function(stepNum, introItem) {
-      // Sets a step to something different than it currently is.
-      if (stepNum > this._introItems.length) {
-        throw new Error('Cannot set step ' + stepNum + '. There are only ' + this._introItems.length + ' steps.');
-      } else if (introItem.element == null || typeof(introItem.element) === 'undefined') {
-        throw new Error('Updated step must have a valid element.');
-      } else {
-        introItem.step = stepNum;
-        this._introItems[stepNum-1] = introItem;
-      }
     },
     exit: function() {
       _exitIntro.call(this, this._targetElement);

--- a/intro.js
+++ b/intro.js
@@ -1735,7 +1735,7 @@
    *                             false means extend it.)
    * @returns this (to facilitate chaining)
    */
-  function _setCallback(functionName, providedCallback, overwrite=false) {
+  function _setCallback(functionName, providedCallback, overwrite) {
     if (typeof (providedCallback) === 'function') {
       var callbackName = _getCallback.call(this, functionName)
       if (overwrite || typeof (this[callbackName]) === 'undefined') {

--- a/intro.js
+++ b/intro.js
@@ -117,8 +117,6 @@
       showHelperLayer: true,
       /* Show tour progress? */
       showProgress: false,
-      /* Show tour progress with bullets? */
-      showProgressBullets: false,
       /* Scroll to highlighted element? */
       scrollToElement: true,
       /* Set the overlay opacity */
@@ -933,7 +931,6 @@
           tooltipLayer      = document.createElement('div'),
           tooltipTextLayer  = document.createElement('div'),
           bulletsLayer      = document.createElement('div'),
-          progressBulletsLayer = document.createElement('div'),
           progressLayer     = document.createElement('div'),
           buttonsLayer      = document.createElement('div');
 
@@ -995,7 +992,6 @@
       tooltipLayer.className = 'introjs-tooltip';
       tooltipLayer.appendChild(tooltipTextLayer);
       tooltipLayer.appendChild(bulletsLayer);
-      tooltipLayer.appendChild(progressBulletsLayer);
       tooltipLayer.appendChild(progressLayer);
 
       //add helper layer number
@@ -1632,64 +1628,6 @@
 
     return elementPosition;
   };
-
-  /**
-   * Creates the progress bullets.
-   *
-   * @api private
-   * @method _createProgressBullets
-   * @returns progress bullets ul element
-   */
-  function _createProgressBullets(progressBulletsLayer) {
-    var progressBulletUlContainer = document.createElement('ul');
-
-    for (var step_num = 0, stepsLength = this._introItems.length; step_num < stepsLength; step_num++) {
-        var connectingBarLi = document.createElement('li')
-        var progressBulletInnerLi = document.createElement('li');
-        var progressBulletDiv = document.createElement('div');
-        var progressBulletSpan = document.createElement('span');
-        progressBulletInnerLi.setAttribute('introjs-progress-bullet', step_num);
-        if (step_num > 0) {
-          connectingBarLi.setAttribute('introjs-progress-bullet-bar', step_num);
-        }
-
-        progressBulletInnerLi.className = 'progress-bullet';
-        connectingBarLi.className = 'connecting-bar';
-        if (step_num <= this._currentStep) {
-          progressBulletInnerLi.className += ' viewed';
-          connectingBarLi.className += ' viewed';
-          progressBulletSpan.innerHTML = '<i class="fa fa-check"></i>';
-        }
-
-        progressBulletInnerLi.appendChild(progressBulletDiv);
-        progressBulletDiv.appendChild(progressBulletSpan);
-        if (step_num > 0) {
-          progressBulletUlContainer.appendChild(connectingBarLi);
-        }
-        progressBulletUlContainer.appendChild(progressBulletInnerLi);
-      }
-
-    progressBulletsLayer.appendChild(progressBulletUlContainer);
-    return progressBulletUlContainer;
-  }
-
-  /**
-   * Updates the progress bullets.
-   *
-   * @api private
-   * @method _updateProgressBullets
-   */
-  function _updateProgressBullets(self, oldReferenceLayer) {
-    for (var step_num = 0; step_num < self._introItems.length; step_num++) {
-      var innerLi = oldReferenceLayer.querySelector('li[introjs-progress-bullet="' + step_num + '"]');
-      innerLi.className = (step_num <= this._currentStep) ? 'progress-bullet viewed' : 'progress-bullet';
-      innerLi.querySelector('span').innerHTML = (step_num <= this._currentStep) ? '<i class="fa fa-check"></i>': '';
-      if (step_num > 0) {
-        var connectingBarLi = oldReferenceLayer.querySelector('li[introjs-progress-bullet-bar="' + step_num + '"]');
-        connectingBarLi.className = (step_num <= this._currentStep) ? 'connecting-bar viewed' : 'connecting-bar';
-      }
-    }
-  }
 
   /**
    * Creates the progress bar.

--- a/intro.js
+++ b/intro.js
@@ -22,7 +22,6 @@
  *   showButtons
  *   showBackButton
  *   showBullets
- *   showHelperLayer
  *   showProgress
  *   scrollToElement
  *   overlayOpacity
@@ -115,7 +114,6 @@
       showBackButton: true,
       /* Show tour bullets? */
       showBullets: true,
-      showHelperLayer: true,
       /* Show tour progress? */
       showProgress: false,
       /* Scroll to highlighted element? */

--- a/intro.js
+++ b/intro.js
@@ -124,7 +124,7 @@
       overlayOpacity: 0.8,
       /* Pixels of highlighted padding around element */
       padding: 5,
-      /* Padding to add after scrolling when element is not in the viewport (in pixels) */		 +      /* Pixels of highlighted padding around element */
+      /* Padding to add after scrolling when element is not in the viewport (in pixels) */
       scrollPadding: 30,
       /* Precedence of positions, when auto is enabled */
       positionPrecedence: ["bottom", "top", "right", "left"],

--- a/intro.js
+++ b/intro.js
@@ -43,6 +43,7 @@
  *   goToStep(step)
  *   nextStep()
  *   previousStep()
+ *   updateStep()
  *   exit()
  *   refresh()
  *   onbeforechange(providedCallback)
@@ -1843,6 +1844,17 @@
     previousStep: function() {
       _previousStep.call(this);
       return this;
+    },
+    updateStep: function(stepNum, introItem) {
+      // Sets a step to something different than it currently is.
+      if (stepNum > this._introItems.length) {
+        throw new Error('Cannot set step ' + stepNum + '. There are only ' + this._introItems.length + ' steps.');
+      } else if (introItem.element == null || typeof(introItem.element) === 'undefined') {
+        throw new Error('Updated step must have a valid element.');
+      } else {
+        introItem.step = stepNum;
+        this._introItems[stepNum-1] = introItem;
+      }
     },
     exit: function() {
       _exitIntro.call(this, this._targetElement);


### PR DESCRIPTION
1) In order to create a custom progress bar, the logic concerning the built-in progress bar was moved into the `_createProgressBar()` and `_updateProgressBar()` functions, a parameter `monkeypatch` was added to `introJs()` and `IntroJS()` and stored in `this._monkeypatch`, and those newly created functions check `this._monkeypatch` for an attribute with the same function name to run that function instead of the built-in one if provided. That is, passing in a parameter `monkeypatch = {'_createProgressBar': function(){...}, '_updateProgressBar': function(){...}}` will substitute these functions for the built-in ones and display the custom progress bar. (Note that it may make sense, both for monkeypatching and for general readability, to do the same for other parts of the tour, for example, `_createBullets()`, `_updateBullets()`, `_createButtons()`, `_updateButtons()`, etc. Also, it may make sense to find a better way to monkeypatch, for example, by moving `IntroJs` into the global scope.)

2) Several new options were added, including:
- `doneClass`: a class for the Done button to make it display with different style than the next/back/skip buttons. Creating a separate button rather than reusing the skip button is probably a better solution.
- `doneClassInsteadOfDefault`: This is a hack used to get `doneClass` to replace `introjs-button` instead of making changes on top of that default class. Losing the `introjs-button` class breaks anything that permits going back to earlier steps in the tour, like the Back button and the Bullets.
- `showBackButton`: Setting this to false removes the Back (Prev) button, so users can only go forward in the tour.
- `padding`: intro.js creates a 5-pixel white border around a highlighted element. This option allows the size of the border to be customized.
- `headerHeight`: Allows setting the size of an area at the top of the screen which is considered off-screen for the purpose of displaying the tour. This can ensure that any page masthead does not get covered by the tour.

3) Added new public function `getStep()` to return the step of the tour we're currently on.

4) I created `_getCallback()` and `_setCallback()` functions for events to (a) avoid repeated code, and (b) to allow the user to add functionality to an event that already has a function, rather than replacing the already existing function (which is the only possibility currently). I set it so that adding functionality is the default, and setting the `overwrite` parameter to true replaces the existing functionality. This let's me create a way for all tours on my site to work, and then allow individual tours on this page or that page to add on their own thing.

5) Some minor changes to flow and naming for clarity.
