### PR TITLE
Add hint count parameter to onhintsadded callback

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -1422,7 +1422,7 @@
 
     // call the callback function (if any)
     if (typeof (this._hintsAddedCallback) !== 'undefined') {
-      this._hintsAddedCallback.call(this);
+      this._hintsAddedCallback.call(this, this._introItems.length);
     }
   };
 


### PR DESCRIPTION
- This parameter denotes the count of hints that were actually
  rendered, which can actually be less than the configured hints, e.g.
  when the CSS selector doesn't select an element. Useful for having
  only one hint configuration for multiple views of single-page
  applications.