### PR TITLE
Remove double quote for keyframe name(Bugfix)

### DIFF
--- a/introjs.css
+++ b/introjs.css
@@ -440,7 +440,7 @@ tr.introjs-showElement > th {
  }
 }
 
-@-webkit-keyframes "introjspulse" {
+@-webkit-keyframes introjspulse {
  0% {
     -webkit-transform: scale(0);
     opacity: 0.0;


### PR DESCRIPTION
## Description:
Remove double quote for keyframe name(Bugfix) - Which resolve the issue of @keyframes missing name error(which also occur in meteor)

## Issue:
- `@keyframes missing name` error occur during meteor build with introjs in either bower or lib/ folder

## Solution:
- Removing double quotes of [line 443](https://github.com/usablica/intro.js/blob/master/introjs.css#L443)
 cause the error to disappear