### PR TITLE
Fixing typo in API documentation for _previousStep() method

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -338,7 +338,7 @@
    * Go to previous step on intro
    *
    * @api private
-   * @method _nextStep
+   * @method _previousStep
    */
   function _previousStep() {
     this._direction = 'backward';


### PR DESCRIPTION
Just a simple one-liner.