### PR TITLE
Fixed going back one step after reaching the last step

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -811,7 +811,10 @@
           skipTooltipButton    = oldReferenceLayer.querySelector('.introjs-skipbutton'),
           prevTooltipButton    = oldReferenceLayer.querySelector('.introjs-prevbutton'),
           nextTooltipButton    = oldReferenceLayer.querySelector('.introjs-nextbutton');
-
+      if (!skipTooltipButton){
+        skipTooltipButton = oldReferenceLayer.querySelector('.introjs-donebutton')
+      }
+      
       //update or reset the helper highlight class
       oldHelperLayer.className = highlightClass;
       //hide the tooltip
@@ -1055,6 +1058,7 @@
       prevTooltipButton.className = 'introjs-button introjs-prevbutton';
       nextTooltipButton.className = 'introjs-button introjs-nextbutton';
       skipTooltipButton.innerHTML = this._options.skipLabel;
+      skipTooltipButton.className = 'introjs-button introjs-skipbutton';
     }
 
     //Set focus on "next" button, so that hitting Enter always moves you onto the next step


### PR DESCRIPTION
Hi!
I found a bug in version 2.5.0.

If you go the the last step and then go back to previous step, the skip button can't be found, cause .introjs-skipbutton class has been overriden by this 9ae68362dd2177dcf9e7751586a51d17fc9b1688.
One solution I found is to search for the new class in case the first one is not found and also to change it back to the initial class.

I'm not very proud of that `if` so if you have a better option, do tell me!

Thanks!