### PR TITLE
Add available since tags for hints API docs

### DIFF
--- a/docs/docs/hints/api.md
+++ b/docs/docs/hints/api.md
@@ -114,6 +114,8 @@ introJs().addHints();
 
 Show the hint with given `hintId`.
 
+**Available since**: v2.4.0
+
 **Example:**
 ```javascript
 introJs().showHint(1);
@@ -124,6 +126,8 @@ introJs().showHint(1);
 ##### introJs.showHints()
 
 Show all hints.
+
+**Available since**: v2.4.0
 
 **Example:**
 ```javascript


### PR DESCRIPTION
Hi, 

I got confused using the angular wrapper for this library which still uses v.2.3 and didn't have the showHint() + showHints() commands, so I've added the 'available since' level to the docs.