### PR TITLE
Makes introjs work with transformed elements

### DIFF
--- a/introjs.css
+++ b/introjs.css
@@ -23,11 +23,16 @@
 .introjs-fixParent {
   z-index: auto !important;
   opacity: 1.0 !important;
-  -webkit-transform: none !important;
-     -moz-transform: none !important;
-      -ms-transform: none !important;
-       -o-transform: none !important;
-          transform: none !important;
+}
+
+.introjs-fixElement {
+  transform-origin: top left !important;
+  position: relative !important;
+  margin: 5px !important;
+  top: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  left: 0 !important;
 }
 
 .introjs-showElement,


### PR DESCRIPTION
Prior to this change, any time parent elements introduced a stacking
context with certain positioning or with transforms, introjs would just
forcibly remove those. For something like opacity, that may not be a big
deal, but when transforms are an integral part of page styling, you
can't just disable them and expect things to render properly.

In those cases, now we clone the highlighted element and plop it right
on top of the highlighting layer--sidestepping the whole z-index problem
to begin with.

This also yanks out the alternate method for positioning, since that
also did not take transforms into account. Now the highlight will be
positioned properly on the page, even when parents are scaled or
translated.