### PR TITLE
Add ability to force a tooltip's position

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -567,7 +567,9 @@
 
     currentTooltipPosition = this._introItems[this._currentStep].position;
 
-    if (currentTooltipPosition != "floating") { // Floating is always valid, no point in calculating
+    if (currentTooltipPosition && currentTooltipPosition.includes(".forced")) {
+      currentTooltipPosition = currentTooltipPosition.split(".forced")[0]
+    } else if (currentTooltipPosition != "floating") { // Floating is always valid, no point in calculating
       if (currentTooltipPosition === "auto") {
         currentTooltipPosition = _determineAutoPosition.call(this, targetElement, tooltipLayer);
       } else {


### PR DESCRIPTION
Small windows (such as mobile) are having position being forced to floating due to auto positioning.
There are cases where this is wrong and we would like it to be forced to attach to the top or bottom of the element.
This commit allow us to simply add ".forced" to the end of the position string in order to completely bypass the auto positioning of IntroJs.