### PR TITLE
Changed camelcase data attributes to lowercase

### DIFF
--- a/docs/docs/hints/attributes.md
+++ b/docs/docs/hints/attributes.md
@@ -8,4 +8,4 @@ permalink: /hints/attributes/
 You can use these HTML attributes to manage or alter hint elements.
 
  - `data-hint`: The tooltip text of hint
- - `data-hintPosition`: Optionally define the position of hint. Options: `top-middle`, `top-left`, `top-right`, `bottom-left`, `bottom-right`, `bottom-middle`, `middle-left`, `middle-right`, `middle-middle`. Default: `top-middle`
+ - `data-hintposition`: Optionally define the position of hint. Options: `top-middle`, `top-left`, `top-right`, `bottom-left`, `bottom-right`, `bottom-middle`, `middle-left`, `middle-right`, `middle-middle`. Default: `top-middle`

--- a/docs/docs/intro/attributes.md
+++ b/docs/docs/intro/attributes.md
@@ -9,8 +9,8 @@ You can use these HTML attributes to manage or alter intro elements.
 
  - `data-intro`: The tooltip text of step
  - `data-step`: Optionally define the number (priority) of step
- - `data-tooltipClass`: Optionally define a CSS class for tooltip
- - `data-highlightClass`: Optionally append a CSS class to the helperLayer
+ - `data-tooltipclass`: Optionally define a CSS class for tooltip
+ - `data-highlightclass`: Optionally append a CSS class to the helperLayer
  - `data-position`: Optionally define the position of tooltip, `top`, `left`, `right`, `bottom`, `bottom-left-aligned` (same as `bottom`), `bottom-middle-aligned`, `bottom-right-aligned` or `auto` (to detect the position of element and assign the correct position automatically). Default is `bottom`
- - `data-scrollTo`: Optionally define the element to scroll to, `element` or `tooltip`. Default is `element`.
+ - `data-scrollto`: Optionally define the element to scroll to, `element` or `tooltip`. Default is `element`.
  - `data-disable-interaction`: To disable interactions with elements inside the highlighted box, `true` or `false` (also `1` or `0`).

--- a/example/callbacks/onbeforechange.html
+++ b/example/callbacks/onbeforechange.html
@@ -40,7 +40,7 @@
       <hr>
 
       <div class="row-fluid marketing">
-        <div class="span6" data-step="2" data-intro="Ok, wasn't that fun?" data-position='right' data-scrollTo='tooltip'>
+        <div class="span6" data-step="2" data-intro="Ok, wasn't that fun?" data-position='right' data-scrollto='tooltip'>
           <h4>Section One</h4>
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
 

--- a/example/custom-class/index.html
+++ b/example/custom-class/index.html
@@ -34,7 +34,7 @@
     <div class="container-narrow">
 
       <div class="masthead">
-        <ul class="nav nav-pills pull-right" data-step="5" data-tooltipClass='forLastStep' data-intro="Get it, use it.">
+        <ul class="nav nav-pills pull-right" data-step="5" data-tooltipclass='forLastStep' data-intro="Get it, use it.">
           <li><a href="https://github.com/usablica/intro.js/tags"><i class='icon-black icon-download-alt'></i> Download</a></li>
           <li><a href="https://github.com/usablica/intro.js">Github</a></li>
           <li><a href="https://twitter.com/usablica">@usablica</a></li>

--- a/example/disable-interaction/index.html
+++ b/example/disable-interaction/index.html
@@ -41,7 +41,7 @@
       <hr>
 
       <div class="row-fluid marketing">
-        <div class="span6" data-step="2" data-intro="Ok, wasn't that fun?" data-position='right' data-scrollTo='tooltip'>
+        <div class="span6" data-step="2" data-intro="Ok, wasn't that fun?" data-position='right' data-scrollto='tooltip'>
           <h4>Section One</h4>
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
 

--- a/intro.js
+++ b/intro.js
@@ -185,10 +185,10 @@
             element: currentElement,
             intro: currentElement.getAttribute('data-intro'),
             step: parseInt(currentElement.getAttribute('data-step'), 10),
-            tooltipClass: currentElement.getAttribute('data-tooltipClass'),
-            highlightClass: currentElement.getAttribute('data-highlightClass'),
+            tooltipClass: currentElement.getAttribute('data-tooltipclass'),
+            highlightClass: currentElement.getAttribute('data-highlightclass'),
             position: currentElement.getAttribute('data-position') || this._options.tooltipPosition,
-            scrollTo: currentElement.getAttribute('data-scrollTo') || this._options.scrollTo,
+            scrollTo: currentElement.getAttribute('data-scrollto') || this._options.scrollTo,
             disableInteraction: disableInteraction
           };
         }
@@ -220,10 +220,10 @@
             element: currentElement,
             intro: currentElement.getAttribute('data-intro'),
             step: nextStep + 1,
-            tooltipClass: currentElement.getAttribute('data-tooltipClass'),
-            highlightClass: currentElement.getAttribute('data-highlightClass'),
+            tooltipClass: currentElement.getAttribute('data-tooltipclass'),
+            highlightClass: currentElement.getAttribute('data-highlightclass'),
             position: currentElement.getAttribute('data-position') || this._options.tooltipPosition,
-            scrollTo: currentElement.getAttribute('data-scrollTo') || this._options.scrollTo,
+            scrollTo: currentElement.getAttribute('data-scrollto') || this._options.scrollTo,
             disableInteraction: disableInteraction
           };
         }
@@ -1600,7 +1600,7 @@
         var currentElement = hints[i];
 
         // hint animation
-        var hintAnimation = currentElement.getAttribute('data-hintAnimation');
+        var hintAnimation = currentElement.getAttribute('data-hintanimation');
 
         if (hintAnimation) {
           hintAnimation = (hintAnimation == 'true');
@@ -1611,9 +1611,9 @@
         this._introItems.push({
           element: currentElement,
           hint: currentElement.getAttribute('data-hint'),
-          hintPosition: currentElement.getAttribute('data-hintPosition') || this._options.hintPosition,
+          hintPosition: currentElement.getAttribute('data-hintposition') || this._options.hintPosition,
           hintAnimation: hintAnimation,
-          tooltipClass: currentElement.getAttribute('data-tooltipClass'),
+          tooltipClass: currentElement.getAttribute('data-tooltipclass'),
           position: currentElement.getAttribute('data-position') || this._options.tooltipPosition
         });
       }


### PR DESCRIPTION
I believe this is already backwards compatible (tested in Chrome and Firefox, at least).  The browsers automatically convert camelcased attributes to lowercase, and both can be accessed successfully via `elem.getAttribute`.

See this [StackOverflow answer](https://stackoverflow.com/questions/22753629/jquery-get-html-5-data-attributes-with-hyphens-and-case-sensitivity) and the notes on how data attributes are "translated": hyphens become camel-case, and uppercase become lowercase.  So this **should** be enough.  If not, we can add a helper function which queries the data attribute and conditionally posts a deprecated warning in the console.

resolves #519