### PR TITLE
Replaces the target element of step

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -1961,14 +1961,14 @@
     _placeTooltip.call(this, hintElement, tooltipLayer, arrowLayer, null, true);
   }
 
-	/**
-	 * Replaces element in a step
-	 *
-	 * @api private
-	 * @method _replaceItemElement
-	 * @param {Number} pos
-	 * @param {Object|String} targetElem
-	 */
+  /**
+   * Replaces element in a step
+   *
+   * @api private
+   * @method _replaceItemElement
+   * @param {Number} pos
+   * @param {Object|String} targetElem
+   */
   function _replaceItemElement(pos, targetElem) {
     if (typeof pos !== 'number' || (!targetElem.jquery && typeof targetElem !== 'string' && !(targetElem instanceof Element)) || pos >= this._introItems.length) {
       return false;
@@ -1984,8 +1984,8 @@
 	  auxElem = targetElem;
 	}
     else if (typeof targetElem !== 'string') {
-        // Gets javascript object from selector
-        auxElem = document.querySelector(targetElem);
+      // Gets javascript object from selector
+      auxElem = document.querySelector(targetElem);
     }
 	if (auxElem === null) {
 	  return false;

--- a/intro.js
+++ b/intro.js
@@ -1975,27 +1975,27 @@
     }
     // Auxiliary element to check against null
     var auxElem = null;
-	if (targetElem.jquery) {
+    if (targetElem.jquery) {
       // Gets javascript object from jQuery
-	  auxElem = targetElem[0];
-	}
-	else if (targetElem instanceof Element) {
-	  // Gets javascript object directly
-	  auxElem = targetElem;
-	}
+      auxElem = targetElem[0];
+    }
+    else if (targetElem instanceof Element) {
+      // Gets javascript object directly
+      auxElem = targetElem;
+    }
     else if (typeof targetElem !== 'string') {
       // Gets javascript object from selector
       auxElem = document.querySelector(targetElem);
     }
-	if (auxElem === null) {
+    if (auxElem === null) {
 	  return false;
-	}
+    }
 
-	this._introItems[pos].element = auxElem;
+    this._introItems[pos].element = auxElem;
 
 	// Remove floating if element is floating
-	if (this._introItems[pos].position === 'floating') {
-	  delete this._introItems[pos].position;
+    if (this._introItems[pos].position === 'floating') {
+      delete this._introItems[pos].position;
     }
 
     return true;

--- a/intro.js
+++ b/intro.js
@@ -1983,7 +1983,7 @@
       // Gets javascript object directly
       auxElem = targetElem;
     }
-    else if (typeof targetElem !== 'string') {
+    else if (typeof targetElem === 'string') {
       // Gets javascript object from selector
       auxElem = document.querySelector(targetElem);
     }

--- a/intro.js
+++ b/intro.js
@@ -1975,11 +1975,7 @@
     }
     // Auxiliary element to check against null
     var auxElem = null;
-    if (typeof targetElem !== 'string') {
-      // Gets javascript object from selector
-	  auxElem = document.querySelector(targetElem);
-    }
-	else if (targetElem.jquery) {
+	if (targetElem.jquery) {
       // Gets javascript object from jQuery
 	  auxElem = targetElem[0];
 	}
@@ -1987,6 +1983,10 @@
 	  // Gets javascript object directly
 	  auxElem = targetElem;
 	}
+    else if (typeof targetElem !== 'string') {
+        // Gets javascript object from selector
+        auxElem = document.querySelector(targetElem);
+    }
 	if (auxElem === null) {
 	  return false;
 	}

--- a/intro.js
+++ b/intro.js
@@ -276,7 +276,7 @@
         if (code === null) {
           code = (e.charCode === null) ? e.keyCode : e.charCode;
         }
-        
+
         if (code === 'Escape' || code === 27 && self._options.exitOnEsc == true) {
           //escape key pressed, exit the intro
           //check if exit callback is defined
@@ -1961,6 +1961,46 @@
     _placeTooltip.call(this, hintElement, tooltipLayer, arrowLayer, null, true);
   }
 
+	/**
+	 * Replaces element in a step
+	 *
+	 * @api private
+	 * @method _replaceItemElement
+	 * @param {Number} pos
+	 * @param {Object|String} targetElem
+	 */
+  function _replaceItemElement(pos, targetElem) {
+    if (typeof pos !== 'number' || (!targetElem.jquery && typeof targetElem !== 'string' && !(targetElem instanceof Element)) || pos >= this._introItems.length) {
+      return false;
+    }
+    // Auxiliary element to check against null
+    var auxElem = null;
+    if (typeof targetElem !== 'string') {
+      // Gets javascript object from selector
+	  auxElem = document.querySelector(targetElem);
+    }
+	else if (targetElem.jquery) {
+      // Gets javascript object from jQuery
+	  auxElem = targetElem[0];
+	}
+	else if (targetElem instanceof Element) {
+	  // Gets javascript object directly
+	  auxElem = targetElem;
+	}
+	if (auxElem === null) {
+	  return false;
+	}
+
+	this._introItems[pos].element = auxElem;
+
+	// Remove floating if element is floating
+	if (this._introItems[pos].position === 'floating') {
+	  delete this._introItems[pos].position;
+    }
+
+    return true;
+
+  }
   /**
    * Get an element position on the page
    * Thanks to `meouw`: http://stackoverflow.com/a/442474/375966
@@ -2226,6 +2266,10 @@
     },
     showHintDialog: function (stepId) {
       _showHintDialog.call(this, stepId);
+      return this;
+    },
+    replaceItemElement: function (pos, targetElem) {
+      _replaceItemElement.call(this, pos, targetElem);
       return this;
     }
   };


### PR DESCRIPTION
There are times when we don't have the element right at the beginning or we want to change them while the steps are being processed and we need to change the element in the middle of the running steps.

Use case:
```
intro.onchange(function(targetElement) {
	if(this._currentStep === 1) {
		$('#example-div').html($('#example-div').html() + '<div id="demo_test"></div>');
		this.replaceItemElement(2, $('#demo_test'));
	}
});
```