### PR TITLE
Position tooltip arrow correctly

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -584,6 +584,7 @@
    */
   function _placeTooltip(targetElement, tooltipLayer, arrowLayer, helperNumberLayer, hintMode) {
     var tooltipCssClass = '',
+        alignArrowHorizontally = false,
         currentStepObj,
         tooltipOffset,
         targetOffset,
@@ -647,6 +648,7 @@
 
         _checkRight(targetOffset, tooltipLayerStyleLeft, tooltipOffset, windowSize, tooltipLayer);
         tooltipLayer.style.bottom = (targetOffset.height +  20) + 'px';
+        alignArrowHorizontally = true;
         break;
       case 'right':
         tooltipLayer.style.left = (targetOffset.width + 20) + 'px';
@@ -725,7 +727,15 @@
         var tooltipLayerStyleLeft = 0;
         _checkRight(targetOffset, tooltipLayerStyleLeft, tooltipOffset, windowSize, tooltipLayer);
         tooltipLayer.style.top    = (targetOffset.height +  20) + 'px';
+        alignArrowHorizontally = true;
         break;
+    }
+      
+    if (alignArrowHorizontally) {
+      const tooltipRect = tooltipLayer.getBoundingClientRect();
+      const targetRect = targetElement.getBoundingClientRect();
+      const arrowRect = arrowLayer.getBoundingClientRect();
+      arrowLayer.style.left = Math.round(targetRect.x - tooltipRect.x + targetRect.width / 2 - arrowRect.width / 2) + 'px';
     }
   }
 


### PR DESCRIPTION
This addresses issue #438. When `top` or some variation of `bottom` is specified, this will position the tooltip's arrow in the center of the target element rather than putting it all the way on the left side.

![image](https://user-images.githubusercontent.com/7192897/31843571-a6d5cb52-b5a8-11e7-998c-d19be0ae867a.png)

Note that I did this before realizing `bottom-middle-aligned` and `bottom-right-aligned` were valid properties, but the equivalents don't exist for `top`. I'm pretty sure that means this overrides what `bottom-X-aligned` does.