### PR TITLE
Fix tooltip and highlight off problem due to scrolling

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -2116,7 +2116,7 @@
       var _y = 0;
       while (element && !isNaN(element.offsetLeft) && !isNaN(element.offsetTop)) {
         _x += element.offsetLeft;
-        _y += element.offsetTop;
+        _y += element.offsetTop - element.scrollTop;
         element = element.offsetParent;
       }
       //set top


### PR DESCRIPTION
We encountered an issue where if an element is scrolled up, the tooltip and helper layer placement become incorrect. Turns out this is because `_getOffset` method didn't take the scrolling into account when looking at and calculating the offsetTop. 

Problem screenshot: 
<img width="613" alt="screen shot 2018-01-08 at 8 03 54 pm" src="https://user-images.githubusercontent.com/28270334/34704601-1ac4ce06-f4af-11e7-95b2-61a8f55207e1.png">
