### PR TITLE
Event listeners with promises === more scripting power for developers

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -38,6 +38,7 @@
         <li><a href="hint/index.html" title='Basic hints usage'>Basic hints usage</a></li>
         <li><a href="hint/withElement.html" title='Basic hints usage on an element'>Basic hints usage on an element</a></li>
         <li><a href="programmatic/hint.html" title='Programmatic defining hints using JSON'>Programmatic defining hints using JSON</a></li>
+        <li><a href="multi-page-promises/index.html" title='Event handling with Promises'>Event handling with Promises</a></li>
       </ul>
     </div>
   </body>

--- a/example/multi-page-promises/index.html
+++ b/example/multi-page-promises/index.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Multi-page introduction, Page 1</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Intro.js - Better introductions for websites and features with a step-by-step guide for your projects.">
+  <meta name="author" content="Afshin Mehrabani (@afshinmeh) in usabli.ca group">
+
+  <!-- styles -->
+  <link href="../assets/css/bootstrap.min.css" rel="stylesheet">
+  <link href="../assets/css/demo.css" rel="stylesheet">
+  <link href="styles.css" rel="stylesheet">
+
+  <!-- Add IntroJs styles -->
+  <link href="../../introjs.css" rel="stylesheet">
+  <link href="../assets/css/bootstrap-responsive.min.css" rel="stylesheet">
+</head>
+
+<body>
+  <div class="page visible">
+    <div class="container-narrow">
+      <div class="masthead">
+        <ul class="nav nav-pills pull-right">
+          <li>
+            <a href="https://github.com/usablica/intro.js/tags">
+              <i class='icon-black icon-download-alt'></i> Download</a>
+          </li>
+          <li>
+            <a href="https://github.com/usablica/intro.js">Github</a>
+          </li>
+          <li>
+            <a href="https://twitter.com/usablica">@usablica</a>
+          </li>
+        </ul>
+        <h3 class="muted">Intro.js</h3>
+      </div>
+
+      <hr>
+
+      <div class="jumbotron">
+        <h1 data-step="1" data-intro="This is a tooltip!">Multi-Page</span>
+        </h1>
+        <p class="lead">Multi-page introduction, you will see three steps of introduction in this page.</p>
+        <a id="startButton" class="btn btn-large btn-success" href="javascript:void(0);">Show me how</a>
+      </div>
+
+      <hr>
+
+      <div class="row-fluid marketing">
+        <div class="span6" data-step="2" data-intro="Ok, wasn't that fun?" data-position='right'>
+          <h4>Section One</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus.
+            Phasellus nec metus purus.</p>
+
+          <h4>Section Two</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus.
+            Phasellus nec metus purus.</p>
+
+          <h4>Section Three</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus.
+            Phasellus nec metus purus.</p>
+        </div>
+
+        <div id="firstPageEnd" class="span6" data-step="3" data-intro="More features, more fun." data-position='left'>
+          <h4>Section Four</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus.
+            Phasellus nec metus purus.</p>
+
+          <h4>Section Five</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus.
+            Phasellus nec metus purus.</p>
+          <h4>Section Six</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus.
+            Phasellus nec metus purus.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="page invisible">
+    <div class="container-narrow">
+      <div class="masthead">
+        <ul class="nav nav-pills pull-right" data-step="5" data-intro="Get it, use it.">
+          <li><a href="https://github.com/usablica/intro.js/tags"><i class='icon-black icon-download-alt'></i> Download</a></li>
+          <li><a href="https://github.com/usablica/intro.js">Github</a></li>
+          <li><a href="https://twitter.com/usablica">@usablica</a></li>
+        </ul>
+        <h3 class="muted">Intro.js</h3>
+      </div>
+
+      <hr>
+
+      <div class="jumbotron">
+        <h1>Second Page</span></h1>
+        <p id="secondPageBegin" class="lead" data-step="4" data-intro="Another step.">Next page of introduction!</p>
+      </div>
+
+      <hr>
+
+      <div class="row-fluid marketing">
+        <div class="span6">
+          <h4>Section One</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+          <h4>Section Two</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+          <h4>Section Three</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+        </div>
+
+        <div class="span6">
+          <h4>Section Four</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+          <h4>Section Five</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+          <h4>Section Six</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script type="text/javascript" src="../../intro.js"></script>
+  <script type="text/javascript">
+    window.onload = function () {
+      var intro = introJs();
+
+      // set up event handling.
+      // switch page based on current element's id. 
+      intro.attachBeforeChange(function (element) {
+        switch (element.id) {
+          case "firstPageEnd":
+            return toPage(1);
+            break;
+          case "secondPageBegin":
+            return toPage(2);
+            break;
+          default:
+        }
+      });
+      
+      document.getElementById('startButton').onclick = intro.start.bind(intro);
+    }
+
+    // functionality for page changes
+    var currentPageNum = 1;
+    function toPage(pageNum) {
+      // do it only when we are not already on the given page
+      if (currentPageNum !== pageNum) {
+        currentPageNum = pageNum;
+        // Return a promise to intro. Resolving the promise will continue
+        // the normal flow. Rejection means abort.
+        // For some events we can also resolve with a boolean value.
+        return new Promise(function(resolve, reject){
+          try {
+            // css manipulation to change the page
+            var visiblePage = document.getElementsByClassName("visible")[0];
+            var invisiblePage = document.getElementsByClassName("invisible")[0];
+            visiblePage.classList.remove("visible");
+            invisiblePage.classList.remove("invisible");
+            visiblePage.classList.add("invisible");
+            invisiblePage.classList.add("visible");
+
+            //timeout until the page change is done, then resolve
+            setTimeout(resolve, 1000);
+          } catch (error) {
+            // in case of failure, just quit intro
+            reject();
+          }
+        });
+      }
+      // Note that undefined is implicitly returned in case the page change was skipped.
+      // This will simply continue the flow.
+    }
+  </script>
+</body>
+
+</html>

--- a/example/multi-page-promises/index.html
+++ b/example/multi-page-promises/index.html
@@ -44,6 +44,7 @@
         </h1>
         <p class="lead">Multi-page introduction, you will see three steps of introduction in this page.</p>
         <a id="startButton" class="btn btn-large btn-success" href="javascript:void(0);">Show me how</a>
+        <a id="secondPageButton" class="btn btn-large pageButton" href="javascript:void(0);">Second page</a>
       </div>
 
       <hr>
@@ -79,7 +80,7 @@
     </div>
   </div>
 
-  <div class="page invisible">
+  <div class="page second invisible">
     <div class="container-narrow">
       <div class="masthead">
         <ul class="nav nav-pills pull-right" data-step="5" data-intro="Get it, use it.">
@@ -95,6 +96,8 @@
       <div class="jumbotron">
         <h1>Second Page</span></h1>
         <p id="secondPageBegin" class="lead" data-step="4" data-intro="Another step.">Next page of introduction!</p>
+        <a id="secondStartButton" class="btn btn-large btn-success" href="javascript:void(0);">Show me how</a>
+        <a id="firstPageButton" class="btn btn-large" href="javascript:void(0);">First page</a>
       </div>
 
       <hr>
@@ -127,10 +130,20 @@
 
   <script type="text/javascript" src="../../intro.js"></script>
   <script type="text/javascript">
+    var currentPageNum = 1;
+    
     window.onload = function () {
+      var introStartPage;
+      
       var intro = introJs();
 
       // set up event handling.
+      // start on first page
+      intro.attachStart(function () {
+        introStartPage = currentPageNum;
+        return toPage(1);
+      });
+
       // switch page based on current element's id. 
       intro.attachBeforeChange(function (element) {
         switch (element.id) {
@@ -143,17 +156,24 @@
           default:
         }
       });
+
+      // after exit, return to the page where the intro was started
+      intro.attachExit(function () {
+        return toPage(introStartPage);
+      });
       
       document.getElementById('startButton').onclick = intro.start.bind(intro);
+      document.getElementById('secondStartButton').onclick = intro.start.bind(intro);
+      document.getElementById('secondPageButton').onclick = function () {toPage(2);};
+      document.getElementById('firstPageButton').onclick = function () {toPage(1);};
     }
 
     // functionality for page changes
-    var currentPageNum = 1;
     function toPage(pageNum) {
       // do it only when we are not already on the given page
       if (currentPageNum !== pageNum) {
         currentPageNum = pageNum;
-        // Return a promise to intro. Resolving the promise will continue
+        // Return a promise to intro. Resolving the promise continues
         // the normal flow. Rejection means abort.
         // For some events we can also resolve with a boolean value.
         return new Promise(function(resolve, reject){
@@ -166,8 +186,8 @@
             visiblePage.classList.add("invisible");
             invisiblePage.classList.add("visible");
 
-            //timeout until the page change is done, then resolve
-            setTimeout(resolve, 1000);
+            // timeout until the page change is done, then resolve
+            setTimeout(resolve, 300);
           } catch (error) {
             // in case of failure, just quit intro
             reject();

--- a/example/multi-page-promises/styles.css
+++ b/example/multi-page-promises/styles.css
@@ -1,0 +1,18 @@
+.page {
+  position: absolute;
+  width: 100%;
+  top: 20px;
+  -webkit-transition: opacity 1s linear;
+  -moz-transition: opacity 1s linear;
+   -ms-transition: opacity 1s linear;
+    -o-transition: opacity 1s linear;
+       transition: opacity 1s linear;
+}
+
+.visible {
+  opacity: 1;
+}
+
+.invisible {
+  opacity: 0;
+}

--- a/example/multi-page-promises/styles.css
+++ b/example/multi-page-promises/styles.css
@@ -2,11 +2,15 @@
   position: absolute;
   width: 100%;
   top: 20px;
-  -webkit-transition: opacity 1s linear;
-  -moz-transition: opacity 1s linear;
-   -ms-transition: opacity 1s linear;
-    -o-transition: opacity 1s linear;
-       transition: opacity 1s linear;
+  -webkit-transition: opacity .3s linear;
+  -moz-transition: opacity .3s linear;
+   -ms-transition: opacity .3s linear;
+    -o-transition: opacity .3s linear;
+       transition: opacity .3s linear;
+}
+
+.page.second {
+  color: firebrick;
 }
 
 .visible {
@@ -15,4 +19,8 @@
 
 .invisible {
   opacity: 0;
+}
+
+.pageButton {
+  color: firebrick;
 }

--- a/intro.js
+++ b/intro.js
@@ -31,240 +31,208 @@
       g.introJs = f();
   }
 })(function () {
-//Default config/variables
-var VERSION = '2.9.0-alpha.1';
+  //Default config/variables
+  var VERSION = '2.9.0-alpha.1';
 
-//Create the list of event names as immutable object.
-//Let's us expose the event names as static property of the IntroJs class. 
-var EVENT_NAMES = Object.create({}, {
-  start: {
-    value: 'Start',
-    writable: false
-  },
-  beforeChange: {
-    value: 'BeforeChange',
-    writable: false
-  },
-  change: {
-    value: 'Change',
-    writable: false
-  },
-  afterChange: {
-    value: 'AfterChange',
-    writable: false
-  },
-  complete: {
-    value: 'Complete',
-    writable: false
-  },
-  hintsAdded: {
-    value: 'HintsAdded',
-    writable: false
-  },
-  hintClick: {
-    value: 'HintClick',
-    writable: false
-  },
-  hintClose: {
-    value: 'HintClose',
-    writable: false
-  },
-  exit: {
-    value: 'Exit',
-    writable: false
-  },
-  beforeExit: {
-    value: 'BeforeExit',
-    writable: false
-  }}
-);
+  //Create the list of event names as immutable object.
+  //Let's us expose the event names as static property of the IntroJs class. 
+  var EVENT_NAMES = Object.create({}, {
+    start: {
+      value: 'Start',
+      writable: false
+    },
+    beforeChange: {
+      value: 'BeforeChange',
+      writable: false
+    },
+    change: {
+      value: 'Change',
+      writable: false
+    },
+    afterChange: {
+      value: 'AfterChange',
+      writable: false
+    },
+    complete: {
+      value: 'Complete',
+      writable: false
+    },
+    hintsAdded: {
+      value: 'HintsAdded',
+      writable: false
+    },
+    hintsShow: {
+      value: 'HintsShow',
+      writable: false
+    },
+    hintClick: {
+      value: 'HintClick',
+      writable: false
+    },
+    hintClose: {
+      value: 'HintClose',
+      writable: false
+    },
+    exit: {
+      value: 'Exit',
+      writable: false
+    },
+    beforeExit: {
+      value: 'BeforeExit',
+      writable: false
+    }}
+  );
 
-/**
- * IntroJs main class
- *
- * @class IntroJs
- */
-function IntroJs(obj) {
-  this._targetElement = obj;
-  this._introItems = [];
+  /**
+   * IntroJs main class
+   *
+   * @class IntroJs
+   */
+  function IntroJs(obj) {
+    this._targetElement = obj;
+    this._introItems = [];
 
-  this._options = {
-    /* Next button label in tooltip box */
-    nextLabel: 'Next &rarr;',
-    /* Previous button label in tooltip box */
-    prevLabel: '&larr; Back',
-    /* Skip button label in tooltip box */
-    skipLabel: 'Skip',
-    /* Done button label in tooltip box */
-    doneLabel: 'Done',
-    /* Hide previous button in the first step? Otherwise, it will be disabled button. */
-    hidePrev: false,
-    /* Hide next button in the last step? Otherwise, it will be disabled button. */
-    hideNext: false,
-    /* Default tooltip box position */
-    tooltipPosition: 'bottom',
-    /* Next CSS class for tooltip boxes */
-    tooltipClass: '',
-    /* CSS class that is added to the helperLayer */
-    highlightClass: '',
-    /* Close introduction when pressing Escape button? */
-    exitOnEsc: true,
-    /* Close introduction when clicking on overlay layer? */
-    exitOnOverlayClick: true,
-    /* Show step numbers in introduction? */
-    showStepNumbers: true,
-    /* Let user use keyboard to navigate the tour? */
-    keyboardNavigation: true,
-    /* Show tour control buttons? */
-    showButtons: true,
-    /* Show tour bullets? */
-    showBullets: true,
-    /* Show tour progress? */
-    showProgress: false,
-    /* Scroll to highlighted element? */
-    scrollToElement: true,
-    /*
-     * Should we scroll the tooltip or target element?
-     *
-     * Options are: 'element' or 'tooltip'
-     */
-    scrollTo: 'element',
-    /* Padding to add after scrolling when element is not in the viewport (in pixels) */
-    scrollPadding: 30,
-    /* Set the overlay opacity */
-    overlayOpacity: 0.8,
-    /* Precedence of positions, when auto is enabled */
-    positionPrecedence: ["bottom", "top", "right", "left"],
-    /* Disable an interaction with element? */
-    disableInteraction: false,
-    /* Set how much padding to be used around helper element */
-    helperElementPadding: 10,
-    /* Default hint position */
-    hintPosition: 'top-middle',
-    /* Hint button label */
-    hintButtonLabel: 'Got it',
-    /* Adding animation to hints? */
-    hintAnimation: true
-  };
+    this._options = {
+      /* Next button label in tooltip box */
+      nextLabel: 'Next &rarr;',
+      /* Previous button label in tooltip box */
+      prevLabel: '&larr; Back',
+      /* Skip button label in tooltip box */
+      skipLabel: 'Skip',
+      /* Done button label in tooltip box */
+      doneLabel: 'Done',
+      /* Hide previous button in the first step? Otherwise, it will be disabled button. */
+      hidePrev: false,
+      /* Hide next button in the last step? Otherwise, it will be disabled button. */
+      hideNext: false,
+      /* Default tooltip box position */
+      tooltipPosition: 'bottom',
+      /* Next CSS class for tooltip boxes */
+      tooltipClass: '',
+      /* CSS class that is added to the helperLayer */
+      highlightClass: '',
+      /* Close introduction when pressing Escape button? */
+      exitOnEsc: true,
+      /* Close introduction when clicking on overlay layer? */
+      exitOnOverlayClick: true,
+      /* Show step numbers in introduction? */
+      showStepNumbers: true,
+      /* Let user use keyboard to navigate the tour? */
+      keyboardNavigation: true,
+      /* Show tour control buttons? */
+      showButtons: true,
+      /* Show tour bullets? */
+      showBullets: true,
+      /* Show tour progress? */
+      showProgress: false,
+      /* Scroll to highlighted element? */
+      scrollToElement: true,
+      /*
+      * Should we scroll the tooltip or target element?
+      *
+      * Options are: 'element' or 'tooltip'
+      */
+      scrollTo: 'element',
+      /* Padding to add after scrolling when element is not in the viewport (in pixels) */
+      scrollPadding: 30,
+      /* Set the overlay opacity */
+      overlayOpacity: 0.8,
+      /* Precedence of positions, when auto is enabled */
+      positionPrecedence: ["bottom", "top", "right", "left"],
+      /* Disable an interaction with element? */
+      disableInteraction: false,
+      /* Set how much padding to be used around helper element */
+      helperElementPadding: 10,
+      /* Default hint position */
+      hintPosition: 'top-middle',
+      /* Hint button label */
+      hintButtonLabel: 'Got it',
+      /* Adding animation to hints? */
+      hintAnimation: true
+    };
 
-  //create eventHandler object; one array for each event.
-  this._eventHandler = {};
-  _forEach(Object.getOwnPropertyNames(EVENT_NAMES), function(key) {
-    this._eventHandler[EVENT_NAMES[key]] = [];
-  }.bind(this));
+    //create eventHandler object; one array for each event.
+    this._eventHandler = {};
+    _forEach(Object.getOwnPropertyNames(EVENT_NAMES), function(key) {
+      this._eventHandler[EVENT_NAMES[key]] = [];
+    }.bind(this));
 
-  // in case of critical failures, this flag can block all event handling
-  this._blockEventHandling = false;
-  // this flag blocks keyboard and mouse/touch events during a step change
-  this._blockUserInteraction = false;
-}
+    // in case of critical failures, this flag can block all event handling
+    this._blockEventHandling = false;
+    // this flag blocks keyboard and mouse/touch events during a step change
+    this._blockUserInteraction = false;
+  }
 
-/**
- * Initiate a new introduction/guide from an element in the page
- *
- * @api private
- * @method _introForElement
- * @param {Object} targetElm
- * @returns {Boolean} Success or not?
- */
-function _introForElement(targetElm) {
-  var introItems = [],
-      self = this;
+  /**
+   * Initiate a new introduction/guide from an element in the page
+   *
+   * @api private
+   * @method _introForElement
+   * @param {Object} targetElm
+   * @returns {Boolean} Success or not?
+   */
+  function _introForElement(targetElm) {
+    var introItems = [],
+        self = this;
 
-  if (this._options.steps) {
-    //use steps passed programmatically
-    _forEach(this._options.steps, function (step) {
-      var currentItem = _cloneObject(step);
+    if (this._options.steps) {
+      //use steps passed programmatically
+      _forEach(this._options.steps, function (step) {
+        var currentItem = _cloneObject(step);
 
-      //set the step
-      currentItem.step = introItems.length + 1;
+        //set the step
+        currentItem.step = introItems.length + 1;
 
-      //use querySelector function only when developer used CSS selector
-      if (typeof (currentItem.element) === 'string') {
-        //grab the element with given selector from the page
-        currentItem.element = document.querySelector(currentItem.element);
-      }
-
-      //intro without element
-      if (typeof (currentItem.element) === 'undefined' || currentItem.element === null) {
-        var floatingElementQuery = document.querySelector(".introjsFloatingElement");
-
-        if (floatingElementQuery === null) {
-          floatingElementQuery = document.createElement('div');
-          floatingElementQuery.className = 'introjsFloatingElement';
-
-          document.body.appendChild(floatingElementQuery);
+        //use querySelector function only when developer used CSS selector
+        if (typeof (currentItem.element) === 'string') {
+          //grab the element with given selector from the page
+          currentItem.element = document.querySelector(currentItem.element);
         }
 
-        currentItem.element  = floatingElementQuery;
-        currentItem.position = 'floating';
-      }
+        //intro without element
+        if (typeof (currentItem.element) === 'undefined' || currentItem.element === null) {
+          var floatingElementQuery = document.querySelector(".introjsFloatingElement");
 
-      currentItem.scrollTo = currentItem.scrollTo || this._options.scrollTo;
+          if (floatingElementQuery === null) {
+            floatingElementQuery = document.createElement('div');
+            floatingElementQuery.className = 'introjsFloatingElement';
 
-      if (typeof (currentItem.disableInteraction) === 'undefined') {
-        currentItem.disableInteraction = this._options.disableInteraction;
-      }
-
-      if (currentItem.element !== null) {
-        introItems.push(currentItem);
-      }        
-    }.bind(this));
-
-  } else {
-    //use steps from data-* annotations
-    var allIntroSteps = targetElm.querySelectorAll('*[data-intro]');
-    var elmsLength = allIntroSteps.length;
-    var disableInteraction;
-
-    //if there's no element to intro
-    if (elmsLength < 1) {
-      return false;
-    }
-
-    _forEach(allIntroSteps, function (currentElement) {
-      // skip hidden elements
-      if (currentElement.style.display === 'none') {
-        return;
-      }
-
-      var step = parseInt(currentElement.getAttribute('data-step'), 10);
-
-      if (typeof (currentElement.getAttribute('data-disable-interaction')) !== 'undefined') {
-        disableInteraction = !!currentElement.getAttribute('data-disable-interaction');
-      } else {
-        disableInteraction = this._options.disableInteraction;
-      }
-
-      if (step > 0) {
-        introItems[step - 1] = {
-          element: currentElement,
-          intro: currentElement.getAttribute('data-intro'),
-          step: parseInt(currentElement.getAttribute('data-step'), 10),
-          tooltipClass: currentElement.getAttribute('data-tooltipclass'),
-          highlightClass: currentElement.getAttribute('data-highlightclass'),
-          position: currentElement.getAttribute('data-position') || this._options.tooltipPosition,
-          scrollTo: currentElement.getAttribute('data-scrollto') || this._options.scrollTo,
-          disableInteraction: disableInteraction
-        };
-      }
-    }.bind(this));
-
-    //next add intro items without data-step
-    //todo: we need a cleanup here, two loops are redundant
-    var nextStep = 0;
-
-    _forEach(allIntroSteps, function (currentElement) {
-      if (currentElement.getAttribute('data-step') === null) {
-
-        while (true) {
-          if (typeof introItems[nextStep] === 'undefined') {
-            break;
-          } else {
-            nextStep++;
+            document.body.appendChild(floatingElementQuery);
           }
-        } 
 
+          currentItem.element  = floatingElementQuery;
+          currentItem.position = 'floating';
+        }
+
+        currentItem.scrollTo = currentItem.scrollTo || this._options.scrollTo;
+
+        if (typeof (currentItem.disableInteraction) === 'undefined') {
+          currentItem.disableInteraction = this._options.disableInteraction;
+        }
+
+        if (currentItem.element !== null) {
+          introItems.push(currentItem);
+        }        
+      }.bind(this));
+
+    } else {
+      //use steps from data-* annotations
+      var allIntroSteps = targetElm.querySelectorAll('*[data-intro]');
+      var elmsLength = allIntroSteps.length;
+      var disableInteraction;
+
+      //if there's no element to intro
+      if (elmsLength < 1) {
+        return false;
+      }
+
+      _forEach(allIntroSteps, function (currentElement) {
+        // skip hidden elements
+        if (currentElement.style.display === 'none') {
+          return;
+        }
+
+        var step = parseInt(currentElement.getAttribute('data-step'), 10);
 
         if (typeof (currentElement.getAttribute('data-disable-interaction')) !== 'undefined') {
           disableInteraction = !!currentElement.getAttribute('data-disable-interaction');
@@ -272,214 +240,287 @@ function _introForElement(targetElm) {
           disableInteraction = this._options.disableInteraction;
         }
 
-        introItems[nextStep] = {
-          element: currentElement,
-          intro: currentElement.getAttribute('data-intro'),
-          step: nextStep + 1,
-          tooltipClass: currentElement.getAttribute('data-tooltipclass'),
-          highlightClass: currentElement.getAttribute('data-highlightclass'),
-          position: currentElement.getAttribute('data-position') || this._options.tooltipPosition,
-          scrollTo: currentElement.getAttribute('data-scrollto') || this._options.scrollTo,
-          disableInteraction: disableInteraction
-        };
-      }
-    }.bind(this));
-  }
+        if (step > 0) {
+          introItems[step - 1] = {
+            element: currentElement,
+            intro: currentElement.getAttribute('data-intro'),
+            step: parseInt(currentElement.getAttribute('data-step'), 10),
+            tooltipClass: currentElement.getAttribute('data-tooltipclass'),
+            highlightClass: currentElement.getAttribute('data-highlightclass'),
+            position: currentElement.getAttribute('data-position') || this._options.tooltipPosition,
+            scrollTo: currentElement.getAttribute('data-scrollto') || this._options.scrollTo,
+            disableInteraction: disableInteraction
+          };
+        }
+      }.bind(this));
 
-  //removing undefined/null elements
-  var tempIntroItems = [];
-  for (var z = 0; z < introItems.length; z++) {
-    if (introItems[z]) {
-      // copy non-falsy values to the end of the array
-      tempIntroItems.push(introItems[z]);  
-    } 
-  }
+      //next add intro items without data-step
+      //todo: we need a cleanup here, two loops are redundant
+      var nextStep = 0;
 
-  introItems = tempIntroItems;
+      _forEach(allIntroSteps, function (currentElement) {
+        if (currentElement.getAttribute('data-step') === null) {
 
-  //Ok, sort all items with given steps
-  introItems.sort(function (a, b) {
-    return a.step - b.step;
-  });
+          while (true) {
+            if (typeof introItems[nextStep] === 'undefined') {
+              break;
+            } else {
+              nextStep++;
+            }
+          } 
 
-  //set it to the introJs object
-  self._introItems = introItems;
 
-  //add overlay layer to the page
-  if(_addOverlayLayer.call(self, targetElm)) {
-    _executeEventListeners.call(this, EVENT_NAMES.start, null).then(function () {
-      //then, start the show
-      _nextStep.call(self);
+          if (typeof (currentElement.getAttribute('data-disable-interaction')) !== 'undefined') {
+            disableInteraction = !!currentElement.getAttribute('data-disable-interaction');
+          } else {
+            disableInteraction = this._options.disableInteraction;
+          }
+
+          introItems[nextStep] = {
+            element: currentElement,
+            intro: currentElement.getAttribute('data-intro'),
+            step: nextStep + 1,
+            tooltipClass: currentElement.getAttribute('data-tooltipclass'),
+            highlightClass: currentElement.getAttribute('data-highlightclass'),
+            position: currentElement.getAttribute('data-position') || this._options.tooltipPosition,
+            scrollTo: currentElement.getAttribute('data-scrollto') || this._options.scrollTo,
+            disableInteraction: disableInteraction
+          };
+        }
+      }.bind(this));
+    }
+
+    //removing undefined/null elements
+    var tempIntroItems = [];
+    for (var z = 0; z < introItems.length; z++) {
+      if (introItems[z]) {
+        // copy non-falsy values to the end of the array
+        tempIntroItems.push(introItems[z]);  
+      } 
+    }
+
+    introItems = tempIntroItems;
+
+    //Ok, sort all items with given steps
+    introItems.sort(function (a, b) {
+      return a.step - b.step;
     });
 
-    self._onKeyDown = function(e) {
-      /*
-      on keyCode:
-      https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
-      This feature has been removed from the Web standards.
-      Though some browsers may still support it, it is in
-      the process of being dropped.
-      Instead, you should use KeyboardEvent.code,
-      if it's implemented.
+    //set it to the introJs object
+    self._introItems = introItems;
 
-      jQuery's approach is to test for
-        (1) e.which, then
-        (2) e.charCode, then
-        (3) e.keyCode
-      https://github.com/jquery/jquery/blob/a6b0705294d336ae2f63f7276de0da1195495363/src/event.js#L638
-      */
-      if (self._blockUserInteraction) return;
-
-      var code = (e.code === null) ? e.which : e.code;
-
-      // if code/e.which is null
-      if (code === null) {
-        code = (e.charCode === null) ? e.keyCode : e.charCode;
-      }
-      
-      if ((code === 'Escape' || code === 27) && self._options.exitOnEsc === true) {
-        //escape key pressed, exit the intro
-        //check if exit callback is defined
-        _exitIntro.call(self, targetElm);
-      } else if (code === 'ArrowLeft' || code === 37) {
-        //left arrow
-        _previousStep.call(self);
-      } else if (code === 'ArrowRight' || code === 39) {
-        //right arrow
+    //add overlay layer to the page
+    if(_addOverlayLayer.call(self, targetElm)) {
+      _executeEventListeners.call(this, EVENT_NAMES.start, null).then(function () {
+        //then, start the show
         _nextStep.call(self);
-      } else if (code === 'Enter' || code === 13) {
-        //srcElement === ie
-        var target = e.target || e.srcElement;
-        if (target && target.className.match('introjs-prevbutton')) {
-          //user hit enter while focusing on previous button
+      });
+
+      self._onKeyDown = function(e) {
+        /*
+        on keyCode:
+        https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
+        This feature has been removed from the Web standards.
+        Though some browsers may still support it, it is in
+        the process of being dropped.
+        Instead, you should use KeyboardEvent.code,
+        if it's implemented.
+
+        jQuery's approach is to test for
+          (1) e.which, then
+          (2) e.charCode, then
+          (3) e.keyCode
+        https://github.com/jquery/jquery/blob/a6b0705294d336ae2f63f7276de0da1195495363/src/event.js#L638
+        */
+        if (self._blockUserInteraction) return;
+
+        var code = (e.code === null) ? e.which : e.code;
+
+        // if code/e.which is null
+        if (code === null) {
+          code = (e.charCode === null) ? e.keyCode : e.charCode;
+        }
+        
+        if ((code === 'Escape' || code === 27) && self._options.exitOnEsc === true) {
+          //escape key pressed, exit the intro
+          //check if exit callback is defined
+          _exitIntro.call(self, targetElm);
+        } else if (code === 'ArrowLeft' || code === 37) {
+          //left arrow
           _previousStep.call(self);
-        } else if (target && target.className.match('introjs-skipbutton')) {
-          //user hit enter while focusing on skip button
-          if (self._introItems.length - 1 === self._currentStep){
-              _executeEventListeners.call(self, EVENT_NAMES.complete, null).then(
-                function() {
-                  _exitIntro.call(self, targetElm);
-                },
-                function(blockEvents) {
-                  _failIntro.call(self, blockEvents);
-                });
-          } else {
-            _exitIntro.call(self, targetElm);
-          }
-        } else {
-          //default behavior for responding to enter  
+        } else if (code === 'ArrowRight' || code === 39) {
+          //right arrow
           _nextStep.call(self);
-        }
+        } else if (code === 'Enter' || code === 13) {
+          //srcElement === ie
+          var target = e.target || e.srcElement;
+          if (target && target.className.match('introjs-prevbutton')) {
+            //user hit enter while focusing on previous button
+            _previousStep.call(self);
+          } else if (target && target.className.match('introjs-skipbutton')) {
+            //user hit enter while focusing on skip button
+            if (self._introItems.length - 1 === self._currentStep){
+                _executeEventListeners.call(self, EVENT_NAMES.complete, null).then(
+                  function() {
+                    _exitIntro.call(self, targetElm);
+                  },
+                  function(blockEvents) {
+                    _failIntro.call(self, blockEvents);
+                  });
+            } else {
+              _exitIntro.call(self, targetElm);
+            }
+          } else {
+            //default behavior for responding to enter  
+            _nextStep.call(self);
+          }
 
-        //prevent default behaviour on hitting Enter, to prevent steps being skipped in some browsers
-        if(e.preventDefault) {
-          e.preventDefault();
+          //prevent default behaviour on hitting Enter, to prevent steps being skipped in some browsers
+          if(e.preventDefault) {
+            e.preventDefault();
+          } else {
+            e.returnValue = false;
+          }
+        }
+      };
+
+      self._onResize = function() {
+        self.refresh.call(self);
+      };
+
+      if (window.addEventListener) {
+        if (this._options.keyboardNavigation) {
+          window.addEventListener('keydown', self._onKeyDown, true);
+        }
+        //for window resize
+        window.addEventListener('resize', self._onResize, true);
+      } else if (document.attachEvent) { //IE
+        if (this._options.keyboardNavigation) {
+          document.attachEvent('onkeydown', self._onKeyDown);
+        }
+        //for window resize
+        document.attachEvent('onresize', self._onResize);
+      }
+    }
+    return false;
+  }
+
+  /*
+  * makes a copy of the object
+  * @api private
+  * @method _cloneObject
+  */
+  function _cloneObject(object) {
+      if (object === null || typeof (object) !== 'object' || typeof (object.nodeType) !== 'undefined') {
+        return object;
+      }
+      var temp = {};
+      for (var key in object) {
+        if (typeof(window.jQuery) !== 'undefined' && object[key] instanceof window.jQuery) {
+          temp[key] = object[key];
         } else {
-          e.returnValue = false;
+          temp[key] = _cloneObject(object[key]);
         }
       }
-    };
-
-    self._onResize = function() {
-      self.refresh.call(self);
-    };
-
-    if (window.addEventListener) {
-      if (this._options.keyboardNavigation) {
-        window.addEventListener('keydown', self._onKeyDown, true);
-      }
-      //for window resize
-      window.addEventListener('resize', self._onResize, true);
-    } else if (document.attachEvent) { //IE
-      if (this._options.keyboardNavigation) {
-        document.attachEvent('onkeydown', self._onKeyDown);
-      }
-      //for window resize
-      document.attachEvent('onresize', self._onResize);
+      return temp;
+  }
+  /**
+   * Go to specific step of introduction
+   *
+   * @api private
+   * @method _goToStep
+   */
+  function _goToStep(step) {
+    //because steps starts with zero
+    this._currentStep = step - 2;
+    if (typeof (this._introItems) !== 'undefined') {
+      _nextStep.call(this);
     }
   }
-  return false;
-}
 
-/*
- * makes a copy of the object
- * @api private
- * @method _cloneObject
-*/
-function _cloneObject(object) {
-    if (object === null || typeof (object) !== 'object' || typeof (object.nodeType) !== 'undefined') {
-      return object;
+  /**
+   * Go to the specific step of introduction with the explicit [data-step] number
+   *
+   * @api private
+   * @method _goToStepNumber
+   */
+  function _goToStepNumber(step) {
+    this._currentStepNumber = step;
+    if (typeof (this._introItems) !== 'undefined') {
+      _nextStep.call(this);
     }
-    var temp = {};
-    for (var key in object) {
-      if (typeof(window.jQuery) !== 'undefined' && object[key] instanceof window.jQuery) {
-        temp[key] = object[key];
-      } else {
-        temp[key] = _cloneObject(object[key]);
-      }
+  }
+
+  /**
+   * Go to next step on intro
+   *
+   * @api private
+   * @method _nextStep
+   */
+  function _nextStep() {
+    this._blockUserInteraction = true;
+    this._direction = 'forward';
+
+    _setLayerOpacity(0);
+
+    if (typeof (this._currentStepNumber) !== 'undefined') {
+      _forEach(this._introItems, function (item, i) {
+        if( item.step === this._currentStepNumber ) {
+          this._currentStep = i - 1;
+          this._currentStepNumber = undefined;
+        }
+      }.bind(this));
     }
-    return temp;
-}
-/**
- * Go to specific step of introduction
- *
- * @api private
- * @method _goToStep
- */
-function _goToStep(step) {
-  //because steps starts with zero
-  this._currentStep = step - 2;
-  if (typeof (this._introItems) !== 'undefined') {
-    _nextStep.call(this);
-  }
-}
 
-/**
- * Go to the specific step of introduction with the explicit [data-step] number
- *
- * @api private
- * @method _goToStepNumber
- */
-function _goToStepNumber(step) {
-  this._currentStepNumber = step;
-  if (typeof (this._introItems) !== 'undefined') {
-    _nextStep.call(this);
-  }
-}
+    if (typeof (this._currentStep) === 'undefined') {
+      this._currentStep = 0;
+    } else {
+        ++this._currentStep;
+    }
 
-/**
- * Go to next step on intro
- *
- * @api private
- * @method _nextStep
- */
-function _nextStep() {
-  this._blockUserInteraction = true;
-  this._direction = 'forward';
+    if ((this._introItems.length) <= this._currentStep) {
+      // execute 'complete' handlers, then exit
+      _executeEventListeners.call(this, EVENT_NAMES.complete, null).then(function() {
+        _exitIntro.call(this, this._targetElement);
+      }.bind(this));
+    } else {
 
-  _setLayerOpacity(0);
+      var nextStep = this._introItems[this._currentStep];
 
-  if (typeof (this._currentStepNumber) !== 'undefined') {
-    _forEach(this._introItems, function (item, i) {
-      if( item.step === this._currentStepNumber ) {
-        this._currentStep = i - 1;
-        this._currentStepNumber = undefined;
-      }
-    }.bind(this));
+      _executeEventListeners.call(this, EVENT_NAMES.beforeChange, true, nextStep.element).then(
+        function(continueStep) {
+          // if `onbeforechange` returned `false`, stop displaying the element
+          if (continueStep === false) {
+            --this._currentStep;
+            return false;
+          }
+          _showElement.call(this, nextStep);
+        }.bind(this)
+      ).catch(
+        function(blockEvents) {
+          _failIntro.call(this, blockEvents);
+        }.bind(this)
+      );
+    }
   }
 
-  if (typeof (this._currentStep) === 'undefined') {
-    this._currentStep = 0;
-  } else {
-      ++this._currentStep;
-  }
+  /**
+   * Go to previous step on intro
+   *
+   * @api private
+   * @method _previousStep
+   */
+  function _previousStep() {
+    this._direction = 'backward';
 
-  if ((this._introItems.length) <= this._currentStep) {
-    // execute 'complete' handlers, then exit
-    _executeEventListeners.call(this, EVENT_NAMES.complete, null).then(function() {
-      _exitIntro.call(this, this._targetElement);
-    }.bind(this));
-  } else {
+    if (this._currentStep === 0) {
+      return false;
+    }
+
+    this._blockUserInteraction = true;
+    _setLayerOpacity(0);
+
+    --this._currentStep;
 
     var nextStep = this._introItems[this._currentStep];
 
@@ -487,9 +528,10 @@ function _nextStep() {
       function(continueStep) {
         // if `onbeforechange` returned `false`, stop displaying the element
         if (continueStep === false) {
-          --this._currentStep;
+          ++this._currentStep;
           return false;
         }
+
         _showElement.call(this, nextStep);
       }.bind(this)
     ).catch(
@@ -498,2102 +540,2066 @@ function _nextStep() {
       }.bind(this)
     );
   }
-}
 
-/**
- * Go to previous step on intro
- *
- * @api private
- * @method _previousStep
- */
-function _previousStep() {
-  this._direction = 'backward';
+  /**
+   * Update placement of the intro objects on the screen
+   * @api private
+   */
+  function _refresh() {
+    // re-align intros
+    _setHelperLayerPosition.call(this, document.querySelector('.introjs-helperLayer'));
+    _setHelperLayerPosition.call(this, document.querySelector('.introjs-tooltipReferenceLayer'));
+    _setHelperLayerPosition.call(this, document.querySelector('.introjs-disableInteraction'));
 
-  if (this._currentStep === 0) {
-    return false;
-  }
-
-  this._blockUserInteraction = true;
-  _setLayerOpacity(0);
-
-  --this._currentStep;
-
-  var nextStep = this._introItems[this._currentStep];
-
-  _executeEventListeners.call(this, EVENT_NAMES.beforeChange, true, nextStep.element).then(
-    function(continueStep) {
-      // if `onbeforechange` returned `false`, stop displaying the element
-      if (continueStep === false) {
-        ++this._currentStep;
-        return false;
-      }
-
-      _showElement.call(this, nextStep);
-    }.bind(this)
-  ).catch(
-    function(blockEvents) {
-      _failIntro.call(this, blockEvents);
-    }.bind(this)
-  );
-}
-
-/**
- * Update placement of the intro objects on the screen
- * @api private
- */
-function _refresh() {
-  // re-align intros
-  _setHelperLayerPosition.call(this, document.querySelector('.introjs-helperLayer'));
-  _setHelperLayerPosition.call(this, document.querySelector('.introjs-tooltipReferenceLayer'));
-  _setHelperLayerPosition.call(this, document.querySelector('.introjs-disableInteraction'));
-
-  // re-align tooltip
-  if(this._currentStep !== undefined && this._currentStep !== null) {
-    var oldHelperNumberLayer = document.querySelector('.introjs-helperNumberLayer'),
-      oldArrowLayer        = document.querySelector('.introjs-arrow'),
-      oldtooltipContainer  = document.querySelector('.introjs-tooltip');
-    _placeTooltip.call(this, this._introItems[this._currentStep].element, oldtooltipContainer, oldArrowLayer, oldHelperNumberLayer);
-  }
-
-  //re-align hints
-  _reAlignHints.call(this);
-  return this;
-}
-
-/**
- * Exit from intro
- *
- * @api private
- * @method _exitIntro
- * @param {Object} targetElement
- * @param {Boolean} force - Setting to `true` will skip the result of beforeExit callback
- */
-function _exitIntro(targetElement, force) {
-  _executeEventListeners.call(this, EVENT_NAMES.beforeExit, true).then(function(continueExit) {
-    // If event handler returns `false`, then skip the exit process.
-    // Skip this check if `force` parameter is `true`.
-    if (!force && continueExit === false) return;
-
-    //remove overlay layers from the page
-    var overlayLayers = targetElement.querySelectorAll('.introjs-overlay');
-
-    if (overlayLayers && overlayLayers.length) {
-      _forEach(overlayLayers, function (overlayLayer) {
-        overlayLayer.style.opacity = 0;
-        window.setTimeout(function () {
-          if (this.parentNode) {
-            this.parentNode.removeChild(this);
-          }
-        }.bind(overlayLayer), 500);
-      }.bind(this));
+    // re-align tooltip
+    if(this._currentStep !== undefined && this._currentStep !== null) {
+      var oldHelperNumberLayer = document.querySelector('.introjs-helperNumberLayer'),
+        oldArrowLayer        = document.querySelector('.introjs-arrow'),
+        oldtooltipContainer  = document.querySelector('.introjs-tooltip');
+      _placeTooltip.call(this, this._introItems[this._currentStep].element, oldtooltipContainer, oldArrowLayer, oldHelperNumberLayer);
     }
 
-    //remove all helper layers
-    var helperLayer = targetElement.querySelector('.introjs-helperLayer');
-    if (helperLayer) {
-      helperLayer.parentNode.removeChild(helperLayer);
-    }
-
-    var referenceLayer = targetElement.querySelector('.introjs-tooltipReferenceLayer');
-    if (referenceLayer) {
-      referenceLayer.parentNode.removeChild(referenceLayer);
-    }
-
-    //remove disableInteractionLayer
-    var disableInteractionLayer = targetElement.querySelector('.introjs-disableInteraction');
-    if (disableInteractionLayer) {
-      disableInteractionLayer.parentNode.removeChild(disableInteractionLayer);
-    }
-
-    //remove intro floating element
-    var floatingElement = document.querySelector('.introjsFloatingElement');
-    if (floatingElement) {
-      floatingElement.parentNode.removeChild(floatingElement);
-    }
-
-    _removeShowElement();
-
-    //remove `introjs-fixParent` class from the elements
-    var fixParents = document.querySelectorAll('.introjs-fixParent');
-    _forEach(fixParents, function (parent) {
-      _removeClass(parent, /introjs-fixParent/g);
-    });
-
-    //clean listeners
-    if (window.removeEventListener) {
-      window.removeEventListener('keydown', this._onKeyDown, true);
-    } else if (document.detachEvent) { //IE
-      document.detachEvent('onkeydown', this._onKeyDown);
-    }
-
-    _executeEventListeners.call(this, EVENT_NAMES.exit, null).then(function() {
-      //set the step to zero
-      this._currentStep = undefined;
-      this._blockEventHandling = false;
-    }.bind(this));
-  }.bind(this));
-}
-
-/**
- * Render tooltip box in the page
- *
- * @api private
- * @method _placeTooltip
- * @param {HTMLElement} targetElement
- * @param {HTMLElement} tooltipLayer
- * @param {HTMLElement} arrowLayer
- * @param {HTMLElement} helperNumberLayer
- * @param {Boolean} hintMode
- */
-function _placeTooltip(targetElement, tooltipLayer, arrowLayer, helperNumberLayer, hintMode) {
-  var tooltipCssClass = '',
-      currentStepObj,
-      tooltipOffset,
-      targetOffset,
-      windowSize,
-      currentTooltipPosition;
-
-  hintMode = hintMode || false;
-
-  //reset the old style
-  tooltipLayer.style.top        = null;
-  tooltipLayer.style.right      = null;
-  tooltipLayer.style.bottom     = null;
-  tooltipLayer.style.left       = null;
-  tooltipLayer.style.marginLeft = null;
-  tooltipLayer.style.marginTop  = null;
-
-  arrowLayer.style.display = 'inherit';
-
-  if (typeof(helperNumberLayer) !== 'undefined' && helperNumberLayer !== null) {
-    helperNumberLayer.style.top  = null;
-    helperNumberLayer.style.left = null;
+    //re-align hints
+    _reAlignHints.call(this);
+    return this;
   }
 
-  //prevent error when `this._currentStep` is undefined
-  if (!this._introItems[this._currentStep]) return;
+  /**
+   * Exit from intro
+   *
+   * @api private
+   * @method _exitIntro
+   * @param {Object} targetElement
+   * @param {Boolean} force - Setting to `true` will skip the result of beforeExit callback
+   */
+  function _exitIntro(targetElement, force) {
+    _executeEventListeners.call(this, EVENT_NAMES.beforeExit, true).then(function(continueExit) {
+      // If event handler returns `false`, then skip the exit process.
+      // Skip this check if `force` parameter is `true`.
+      if (!force && continueExit === false) return;
 
-  //if we have a custom css class for each step
-  currentStepObj = this._introItems[this._currentStep];
-  if (typeof (currentStepObj.tooltipClass) === 'string') {
-    tooltipCssClass = currentStepObj.tooltipClass;
-  } else {
-    tooltipCssClass = this._options.tooltipClass;
-  }
+      //remove overlay layers from the page
+      var overlayLayers = targetElement.querySelectorAll('.introjs-overlay');
 
-  tooltipLayer.className = ('introjs-tooltip ' + tooltipCssClass).replace(/^\s+|\s+$/g, '');
-  tooltipLayer.setAttribute('role', 'dialog');
-
-  currentTooltipPosition = this._introItems[this._currentStep].position;
-
-  // Floating is always valid, no point in calculating
-  if (currentTooltipPosition !== "floating") { 
-    currentTooltipPosition = _determineAutoPosition.call(this, targetElement, tooltipLayer, currentTooltipPosition);
-  }
-
-  var tooltipLayerStyleLeft;
-  targetOffset  = _getOffset(targetElement);
-  tooltipOffset = _getOffset(tooltipLayer);
-  windowSize    = _getWinSize();
-
-  _addClass(tooltipLayer, 'introjs-' + currentTooltipPosition);
-
-  switch (currentTooltipPosition) {
-    case 'top-right-aligned':
-      arrowLayer.className      = 'introjs-arrow bottom-right';
-
-      var tooltipLayerStyleRight = 0;
-      _checkLeft(targetOffset, tooltipLayerStyleRight, tooltipOffset, tooltipLayer);
-      tooltipLayer.style.bottom    = (targetOffset.height +  20) + 'px';
-      break;
-
-    case 'top-middle-aligned':
-      arrowLayer.className      = 'introjs-arrow bottom-middle';
-
-      var tooltipLayerStyleLeftRight = targetOffset.width / 2 - tooltipOffset.width / 2;
-
-      // a fix for middle aligned hints
-      if (hintMode) {
-        tooltipLayerStyleLeftRight += 5;
+      if (overlayLayers && overlayLayers.length) {
+        _forEach(overlayLayers, function (overlayLayer) {
+          overlayLayer.style.opacity = 0;
+          window.setTimeout(function () {
+            if (this.parentNode) {
+              this.parentNode.removeChild(this);
+            }
+          }.bind(overlayLayer), 500);
+        }.bind(this));
       }
 
-      if (_checkLeft(targetOffset, tooltipLayerStyleLeftRight, tooltipOffset, tooltipLayer)) {
-        tooltipLayer.style.right = null;
-        _checkRight(targetOffset, tooltipLayerStyleLeftRight, tooltipOffset, windowSize, tooltipLayer);
-      }
-      tooltipLayer.style.bottom = (targetOffset.height + 20) + 'px';
-      break;
-
-    case 'top-left-aligned':
-    // top-left-aligned is the same as the default top
-    case 'top':
-      arrowLayer.className = 'introjs-arrow bottom';
-
-      tooltipLayerStyleLeft = (hintMode) ? 0 : 15;
-
-      _checkRight(targetOffset, tooltipLayerStyleLeft, tooltipOffset, windowSize, tooltipLayer);
-      tooltipLayer.style.bottom = (targetOffset.height +  20) + 'px';
-      break;
-    case 'right':
-      tooltipLayer.style.left = (targetOffset.width + 20) + 'px';
-      if (targetOffset.top + tooltipOffset.height > windowSize.height) {
-        // In this case, right would have fallen below the bottom of the screen.
-        // Modify so that the bottom of the tooltip connects with the target
-        arrowLayer.className = "introjs-arrow left-bottom";
-        tooltipLayer.style.top = "-" + (tooltipOffset.height - targetOffset.height - 20) + "px";
-      } else {
-        arrowLayer.className = 'introjs-arrow left';
-      }
-      break;
-    case 'left':
-      if (!hintMode && this._options.showStepNumbers === true) {
-        tooltipLayer.style.top = '15px';
+      //remove all helper layers
+      var helperLayer = targetElement.querySelector('.introjs-helperLayer');
+      if (helperLayer) {
+        helperLayer.parentNode.removeChild(helperLayer);
       }
 
-      if (targetOffset.top + tooltipOffset.height > windowSize.height) {
-        // In this case, left would have fallen below the bottom of the screen.
-        // Modify so that the bottom of the tooltip connects with the target
-        tooltipLayer.style.top = "-" + (tooltipOffset.height - targetOffset.height - 20) + "px";
-        arrowLayer.className = 'introjs-arrow right-bottom';
-      } else {
-        arrowLayer.className = 'introjs-arrow right';
-      }
-      tooltipLayer.style.right = (targetOffset.width + 20) + 'px';
-
-      break;
-    case 'floating':
-      arrowLayer.style.display = 'none';
-
-      //we have to adjust the top and left of layer manually for intro items without element
-      tooltipLayer.style.left   = '50%';
-      tooltipLayer.style.top    = '50%';
-      tooltipLayer.style.marginLeft = '-' + (tooltipOffset.width / 2)  + 'px';
-      tooltipLayer.style.marginTop  = '-' + (tooltipOffset.height / 2) + 'px';
-
-      if (typeof(helperNumberLayer) !== 'undefined' && helperNumberLayer !== null) {
-        helperNumberLayer.style.left = '-' + ((tooltipOffset.width / 2) + 18) + 'px';
-        helperNumberLayer.style.top  = '-' + ((tooltipOffset.height / 2) + 18) + 'px';
+      var referenceLayer = targetElement.querySelector('.introjs-tooltipReferenceLayer');
+      if (referenceLayer) {
+        referenceLayer.parentNode.removeChild(referenceLayer);
       }
 
-      break;
-    case 'bottom-right-aligned':
-      arrowLayer.className      = 'introjs-arrow top-right';
-
-      tooltipLayerStyleRight = 0;
-      _checkLeft(targetOffset, tooltipLayerStyleRight, tooltipOffset, tooltipLayer);
-      tooltipLayer.style.top    = (targetOffset.height +  20) + 'px';
-      break;
-
-    case 'bottom-middle-aligned':
-      arrowLayer.className      = 'introjs-arrow top-middle';
-
-      tooltipLayerStyleLeftRight = targetOffset.width / 2 - tooltipOffset.width / 2;
-
-      // a fix for middle aligned hints
-      if (hintMode) {
-        tooltipLayerStyleLeftRight += 5;
-      }
-
-      if (_checkLeft(targetOffset, tooltipLayerStyleLeftRight, tooltipOffset, tooltipLayer)) {
-        tooltipLayer.style.right = null;
-        _checkRight(targetOffset, tooltipLayerStyleLeftRight, tooltipOffset, windowSize, tooltipLayer);
-      }
-      tooltipLayer.style.top = (targetOffset.height + 20) + 'px';
-      break;
-
-    // case 'bottom-left-aligned':
-    // Bottom-left-aligned is the same as the default bottom
-    // case 'bottom':
-    // Bottom going to follow the default behavior
-    default:
-      arrowLayer.className = 'introjs-arrow top';
-
-      tooltipLayerStyleLeft = 0;
-      _checkRight(targetOffset, tooltipLayerStyleLeft, tooltipOffset, windowSize, tooltipLayer);
-      tooltipLayer.style.top    = (targetOffset.height +  20) + 'px';
-  }
-}
-
-/**
- * Set tooltip left so it doesn't go off the right side of the window
- *
- * @return boolean true, if tooltipLayerStyleLeft is ok.  false, otherwise.
- */
-function _checkRight(targetOffset, tooltipLayerStyleLeft, tooltipOffset, windowSize, tooltipLayer) {
-  if (targetOffset.left + tooltipLayerStyleLeft + tooltipOffset.width > windowSize.width) {
-    // off the right side of the window
-    tooltipLayer.style.left = (windowSize.width - tooltipOffset.width - targetOffset.left) + 'px';
-    return false;
-  }
-  tooltipLayer.style.left = tooltipLayerStyleLeft + 'px';
-  return true;
-}
-
-/**
- * Set tooltip right so it doesn't go off the left side of the window
- *
- * @return boolean true, if tooltipLayerStyleRight is ok.  false, otherwise.
- */
-function _checkLeft(targetOffset, tooltipLayerStyleRight, tooltipOffset, tooltipLayer) {
-  if (targetOffset.left + targetOffset.width - tooltipLayerStyleRight - tooltipOffset.width < 0) {
-    // off the left side of the window
-    tooltipLayer.style.left = (-targetOffset.left) + 'px';
-    return false;
-  }
-  tooltipLayer.style.right = tooltipLayerStyleRight + 'px';
-  return true;
-}
-
-/**
- * Determines the position of the tooltip based on the position precedence and availability
- * of screen space.
- *
- * @param {Object}    targetElement
- * @param {Object}    tooltipLayer
- * @param {String}    desiredTooltipPosition
- * @return {String}   calculatedPosition
- */
-function _determineAutoPosition(targetElement, tooltipLayer, desiredTooltipPosition) {
-
-  // Take a clone of position precedence. These will be the available
-  var possiblePositions = this._options.positionPrecedence.slice();
-
-  var windowSize = _getWinSize();
-  var tooltipHeight = _getOffset(tooltipLayer).height + 10;
-  var tooltipWidth = _getOffset(tooltipLayer).width + 20;
-  var targetElementRect = targetElement.getBoundingClientRect();
-
-  // If we check all the possible areas, and there are no valid places for the tooltip, the element
-  // must take up most of the screen real estate. Show the tooltip floating in the middle of the screen.
-  var calculatedPosition = "floating";
-
-  /*
-  * auto determine position 
-  */
-
-  // Check for space below
-  if (targetElementRect.bottom + tooltipHeight + tooltipHeight > windowSize.height) {
-    _removeEntry(possiblePositions, "bottom");
-  }
-
-  // Check for space above
-  if (targetElementRect.top - tooltipHeight < 0) {
-    _removeEntry(possiblePositions, "top");
-  }
-
-  // Check for space to the right
-  if (targetElementRect.right + tooltipWidth > windowSize.width) {
-    _removeEntry(possiblePositions, "right");
-  }
-
-  // Check for space to the left
-  if (targetElementRect.left - tooltipWidth < 0) {
-    _removeEntry(possiblePositions, "left");
-  }
-
-  // @var {String}  ex: 'right-aligned'
-  var desiredAlignment = (function (pos) {
-    var hyphenIndex = pos.indexOf('-');
-    if (hyphenIndex !== -1) {
-      // has alignment
-      return pos.substr(hyphenIndex);
-    }
-    return '';
-  })(desiredTooltipPosition || '');
-
-  // strip alignment from position
-  if (desiredTooltipPosition) {
-    // ex: "bottom-right-aligned"
-    // should return 'bottom'
-    desiredTooltipPosition = desiredTooltipPosition.split('-')[0];
-  }
-
-  if (possiblePositions.length) {
-    if (desiredTooltipPosition !== "auto" &&
-        possiblePositions.indexOf(desiredTooltipPosition) > -1) {
-      // If the requested position is in the list, choose that
-      calculatedPosition = desiredTooltipPosition;
-    } else {
-      // Pick the first valid position, in order
-      calculatedPosition = possiblePositions[0];
-    }
-  }
-
-  // only top and bottom positions have optional alignments
-  if (['top', 'bottom'].indexOf(calculatedPosition) !== -1) {
-    calculatedPosition += _determineAutoAlignment(targetElementRect.left, tooltipWidth, windowSize, desiredAlignment);
-  }
-
-  return calculatedPosition;
-}
-
-/**
-* auto-determine alignment
-* @param {Integer}  offsetLeft
-* @param {Integer}  tooltipWidth
-* @param {Object}   windowSize
-* @param {String}   desiredAlignment
-* @return {String}  calculatedAlignment
-*/
-function _determineAutoAlignment (offsetLeft, tooltipWidth, windowSize, desiredAlignment) {
-  var halfTooltipWidth = tooltipWidth / 2,
-    winWidth = Math.min(windowSize.width, window.screen.width),
-    possibleAlignments = ['-left-aligned', '-middle-aligned', '-right-aligned'],
-    calculatedAlignment = '';
-  
-  // valid left must be at least a tooltipWidth
-  // away from right side
-  if (winWidth - offsetLeft < tooltipWidth) {
-    _removeEntry(possibleAlignments, '-left-aligned');
-  }
-
-  // valid middle must be at least half 
-  // width away from both sides
-  if (offsetLeft < halfTooltipWidth || 
-    winWidth - offsetLeft < halfTooltipWidth) {
-    _removeEntry(possibleAlignments, '-middle-aligned');
-  }
-
-  // valid right must be at least a tooltipWidth
-  // width away from left side
-  if (offsetLeft < tooltipWidth) {
-    _removeEntry(possibleAlignments, '-right-aligned');
-  }
-
-  if (possibleAlignments.length) {
-    if (possibleAlignments.indexOf(desiredAlignment) !== -1) {
-      // the desired alignment is valid
-      calculatedAlignment = desiredAlignment;
-    } else {
-      // pick the first valid position, in order
-      calculatedAlignment = possibleAlignments[0];
-    }
-  } else {
-    // if screen width is too small 
-    // for ANY alignment, middle is 
-    // probably the best for visibility
-    calculatedAlignment = '-middle-aligned';
-  }
-
-  return calculatedAlignment;
-}
-
-/**
- * Remove an entry from a string array if it's there, does nothing if it isn't there.
- *
- * @param {Array} stringArray
- * @param {String} stringToRemove
- */
-function _removeEntry(stringArray, stringToRemove) {
-  if (stringArray.indexOf(stringToRemove) > -1) {
-    stringArray.splice(stringArray.indexOf(stringToRemove), 1);
-  }
-}
-
-/**
- * Update the position of the helper layer on the screen
- *
- * @api private
- * @method _setHelperLayerPosition
- * @param {Object} helperLayer
- */
-function _setHelperLayerPosition(helperLayer) {
-  if (helperLayer) {
-    //prevent error when `this._currentStep` in undefined
-    if (!this._introItems[this._currentStep]) return;
-
-    var currentElement  = this._introItems[this._currentStep],
-        elementPosition = _getOffset(currentElement.element),
-        widthHeightPadding = this._options.helperElementPadding;
-
-    // If the target element is fixed, the tooltip should be fixed as well.
-    // Otherwise, remove a fixed class that may be left over from the previous
-    // step.
-    if (_isFixed(currentElement.element)) {
-      _addClass(helperLayer, 'introjs-fixedTooltip');
-    } else {
-      _removeClass(helperLayer, 'introjs-fixedTooltip');
-    }
-
-    if (currentElement.position === 'floating') {
-      widthHeightPadding = 0;
-    }
-
-    //set new position to helper layer
-    helperLayer.setAttribute('style', 'width: ' + (elementPosition.width  + widthHeightPadding)  + 'px; ' +
-                                      'height:' + (elementPosition.height + widthHeightPadding)  + 'px; ' +
-                                      'top:'    + (elementPosition.top    - widthHeightPadding / 2)   + 'px;' +
-                                      'left: '  + (elementPosition.left   - widthHeightPadding / 2)   + 'px;');
-
-  }
-}
-
-/**
- * Add disableinteraction layer and adjust the size and position of the layer
- *
- * @api private
- * @method _disableInteraction
- */
-function _disableInteraction() {
-  var disableInteractionLayer = document.querySelector('.introjs-disableInteraction');
-
-  if (disableInteractionLayer === null) {
-    disableInteractionLayer = document.createElement('div');
-    disableInteractionLayer.className = 'introjs-disableInteraction';
-    this._targetElement.appendChild(disableInteractionLayer);
-  }
-
-  _setHelperLayerPosition.call(this, disableInteractionLayer);
-}
-
-/**
- * Setting anchors to behave like buttons
- *
- * @api private
- * @method _setAnchorAsButton
- */
-function _setAnchorAsButton(anchor){
-  anchor.setAttribute('role', 'button');
-  anchor.tabIndex = 0;
-}
-
-/**
- * Show an element on the page
- *
- * @api private
- * @method _showElement
- * @param {Object} targetElement
- */
-function _showElement(targetElement) {
-  _executeEventListeners.call(this, EVENT_NAMES.change, null, targetElement.element).then(
-    function() {
-      var self = this,
-          oldHelperLayer = document.querySelector('.introjs-helperLayer'),
-          oldReferenceLayer = document.querySelector('.introjs-tooltipReferenceLayer'),
-          highlightClass = 'introjs-helperLayer',
-          nextTooltipButton,
-          prevTooltipButton,
-          skipTooltipButton;
-
-      //check for a current step highlight class
-      if (typeof (targetElement.highlightClass) === 'string') {
-        highlightClass += (' ' + targetElement.highlightClass);
-      }
-      //check for options highlight class
-      if (typeof (this._options.highlightClass) === 'string') {
-        highlightClass += (' ' + this._options.highlightClass);
-      }
-
-      if (oldHelperLayer !== null) {
-        var oldHelperNumberLayer = oldReferenceLayer.querySelector('.introjs-helperNumberLayer'),
-            oldtooltipLayer      = oldReferenceLayer.querySelector('.introjs-tooltiptext'),
-            oldArrowLayer        = oldReferenceLayer.querySelector('.introjs-arrow'),
-            oldtooltipContainer  = oldReferenceLayer.querySelector('.introjs-tooltip');
-            
-        skipTooltipButton    = oldReferenceLayer.querySelector('.introjs-skipbutton');
-        prevTooltipButton    = oldReferenceLayer.querySelector('.introjs-prevbutton');
-        nextTooltipButton    = oldReferenceLayer.querySelector('.introjs-nextbutton');
-
-        //update or reset the helper highlight class
-        oldHelperLayer.className = highlightClass;
-        //hide the tooltip
-        oldtooltipContainer.style.opacity = 0;
-        oldtooltipContainer.style.display = "none";
-
-        if (oldHelperNumberLayer !== null) {
-          var lastIntroItem = this._introItems[(targetElement.step - 2 >= 0 ? targetElement.step - 2 : 0)];
-
-          if (lastIntroItem !== null && (this._direction === 'forward' && lastIntroItem.position === 'floating') || (this._direction === 'backward' && targetElement.position === 'floating')) {
-            oldHelperNumberLayer.style.opacity = 0;
-          }
-        }
-
-        //set new position to helper layer
-        _setHelperLayerPosition.call(self, oldHelperLayer);
-        _setHelperLayerPosition.call(self, oldReferenceLayer);
-
-        //remove `introjs-fixParent` class from the elements
-        var fixParents = document.querySelectorAll('.introjs-fixParent');
-        _forEach(fixParents, function (parent) {
-          _removeClass(parent, /introjs-fixParent/g);
-        });
-        
-        //remove old classes if the element still exist
-        _removeShowElement();
-
-        //we should wait until the CSS3 transition is competed (it's 0.3 sec) to prevent incorrect `height` and `width` calculation
-        if (self._lastShowElementTimer) {
-          window.clearTimeout(self._lastShowElementTimer);
-        }
-
-        self._lastShowElementTimer = window.setTimeout(function() {
-          //set current step to the label
-          if (oldHelperNumberLayer !== null) {
-            oldHelperNumberLayer.innerHTML = targetElement.step;
-          }
-          //set current tooltip text
-          oldtooltipLayer.innerHTML = targetElement.intro;
-          //set the tooltip position
-          oldtooltipContainer.style.display = "block";
-          _placeTooltip.call(self, targetElement.element, oldtooltipContainer, oldArrowLayer, oldHelperNumberLayer);
-
-          //change active bullet
-          if (self._options.showBullets) {
-              oldReferenceLayer.querySelector('.introjs-bullets li > a.active').className = '';
-              oldReferenceLayer.querySelector('.introjs-bullets li > a[data-stepnumber="' + targetElement.step + '"]').className = 'active';
-          }
-          oldReferenceLayer.querySelector('.introjs-progress .introjs-progressbar').setAttribute('style', 'width:' + _getProgress.call(self) + '%;');
-          oldReferenceLayer.querySelector('.introjs-progress .introjs-progressbar').setAttribute('aria-valuenow', _getProgress.call(self));
-
-          //show the tooltip
-          oldtooltipContainer.style.opacity = 1;
-          if (oldHelperNumberLayer) oldHelperNumberLayer.style.opacity = 1;
-
-          //reset button focus
-          if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null && /introjs-donebutton/gi.test(skipTooltipButton.className)) {
-            // skip button is now "done" button
-            skipTooltipButton.focus();
-          } else if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
-            //still in the tour, focus on next
-            nextTooltipButton.focus();
-          }
-
-          // change the scroll of the window, if needed
-          _scrollTo.call(self, targetElement.scrollTo, targetElement, oldtooltipLayer);
-        }, 350);
-
-        // end of old element if-else condition
-      } else {
-        var helperLayer       = document.createElement('div'),
-            referenceLayer    = document.createElement('div'),
-            arrowLayer        = document.createElement('div'),
-            tooltipLayer      = document.createElement('div'),
-            tooltipTextLayer  = document.createElement('div'),
-            bulletsLayer      = document.createElement('div'),
-            progressLayer     = document.createElement('div'),
-            buttonsLayer      = document.createElement('div');
-
-        helperLayer.className = highlightClass;
-        referenceLayer.className = 'introjs-tooltipReferenceLayer';
-
-        //set new position to helper layer
-        _setHelperLayerPosition.call(self, helperLayer);
-        _setHelperLayerPosition.call(self, referenceLayer);
-
-        //add helper layer to target element
-        this._targetElement.appendChild(helperLayer);
-        this._targetElement.appendChild(referenceLayer);
-
-        arrowLayer.className = 'introjs-arrow';
-
-        tooltipTextLayer.className = 'introjs-tooltiptext';
-        tooltipTextLayer.innerHTML = targetElement.intro;
-
-        bulletsLayer.className = 'introjs-bullets';
-
-        if (this._options.showBullets === false) {
-          bulletsLayer.style.display = 'none';
-        }
-
-        var ulContainer = document.createElement('ul');
-        ulContainer.setAttribute('role', 'tablist');
-
-        var anchorClick = function () {
-            if (self._blockUserInteraction) return;
-            self.goToStep(this.getAttribute('data-stepnumber'));
-        };
-
-        _forEach(this._introItems, function (item, i) {
-          var innerLi    = document.createElement('li');
-          var anchorLink = document.createElement('a');
-          
-          innerLi.setAttribute('role', 'presentation');
-          anchorLink.setAttribute('role', 'tab');
-
-          anchorLink.onclick = anchorClick;
-
-          if (i === (targetElement.step-1)) {
-            anchorLink.className = 'active';
-          } 
-
-          _setAnchorAsButton(anchorLink);
-          anchorLink.innerHTML = "&nbsp;";
-          anchorLink.setAttribute('data-stepnumber', item.step);
-
-          innerLi.appendChild(anchorLink);
-          ulContainer.appendChild(innerLi);
-        });
-
-        bulletsLayer.appendChild(ulContainer);
-
-        progressLayer.className = 'introjs-progress';
-
-        if (this._options.showProgress === false) {
-          progressLayer.style.display = 'none';
-        }
-        var progressBar = document.createElement('div');
-        progressBar.className = 'introjs-progressbar';
-        progressBar.setAttribute('role', 'progress');
-        progressBar.setAttribute('aria-valuemin', 0);
-        progressBar.setAttribute('aria-valuemax', 100);
-        progressBar.setAttribute('aria-valuenow', _getProgress.call(this));
-        progressBar.setAttribute('style', 'width:' + _getProgress.call(this) + '%;');
-
-        progressLayer.appendChild(progressBar);
-
-        buttonsLayer.className = 'introjs-tooltipbuttons';
-        if (this._options.showButtons === false) {
-          buttonsLayer.style.display = 'none';
-        }
-
-        tooltipLayer.className = 'introjs-tooltip';
-        tooltipLayer.appendChild(tooltipTextLayer);
-        tooltipLayer.appendChild(bulletsLayer);
-        tooltipLayer.appendChild(progressLayer);
-
-        //add helper layer number
-        var helperNumberLayer = document.createElement('span');
-        if (this._options.showStepNumbers === true) {
-          helperNumberLayer.className = 'introjs-helperNumberLayer';
-          helperNumberLayer.innerHTML = targetElement.step;
-          referenceLayer.appendChild(helperNumberLayer);
-        }
-
-        tooltipLayer.appendChild(arrowLayer);
-        referenceLayer.appendChild(tooltipLayer);
-
-        //next button
-        nextTooltipButton = document.createElement('a');
-
-        nextTooltipButton.onclick = function() {
-          if (self._blockUserInteraction) return;
-          if (self._introItems.length - 1 !== self._currentStep) {
-            _nextStep.call(self);
-          }
-        };
-
-        _setAnchorAsButton(nextTooltipButton);
-        nextTooltipButton.innerHTML = this._options.nextLabel;
-
-        //previous button
-        prevTooltipButton = document.createElement('a');
-
-        prevTooltipButton.onclick = function() {
-          if (self._blockUserInteraction) return;
-          if (self._currentStep !== 0) {
-            _previousStep.call(self);
-          }
-        };
-
-        _setAnchorAsButton(prevTooltipButton);
-        prevTooltipButton.innerHTML = this._options.prevLabel;
-
-        //skip button
-        skipTooltipButton = document.createElement('a');
-        skipTooltipButton.className = 'introjs-button introjs-skipbutton';
-        _setAnchorAsButton(skipTooltipButton);
-        skipTooltipButton.innerHTML = this._options.skipLabel;
-
-        skipTooltipButton.onclick = function() {
-          if (self._blockUserInteraction) return;
-          if (self._introItems.length - 1 === self._currentStep) {
-            _executeEventListeners.call(self, EVENT_NAMES.complete, null).then(function() {
-              _exitIntro.call(self, self._targetElement);
-            });
-          } else {
-            _exitIntro.call(self, self._targetElement);
-          }
-        };
-
-        buttonsLayer.appendChild(skipTooltipButton);
-
-        //in order to prevent displaying next/previous button always
-        if (this._introItems.length > 1) {
-          buttonsLayer.appendChild(prevTooltipButton);
-          buttonsLayer.appendChild(nextTooltipButton);
-        }
-
-        tooltipLayer.appendChild(buttonsLayer);
-
-        //set proper position
-        _placeTooltip.call(self, targetElement.element, tooltipLayer, arrowLayer, helperNumberLayer);
-
-        // change the scroll of the window, if needed
-        _scrollTo.call(this, targetElement.scrollTo, targetElement, tooltipLayer);
-
-        //end of new element if-else condition
-      }
-
-      // removing previous disable interaction layer
-      var disableInteractionLayer = self._targetElement.querySelector('.introjs-disableInteraction');
+      //remove disableInteractionLayer
+      var disableInteractionLayer = targetElement.querySelector('.introjs-disableInteraction');
       if (disableInteractionLayer) {
         disableInteractionLayer.parentNode.removeChild(disableInteractionLayer);
       }
 
-      //disable interaction
-      if (targetElement.disableInteraction) {
-        _disableInteraction.call(self);
+      //remove intro floating element
+      var floatingElement = document.querySelector('.introjsFloatingElement');
+      if (floatingElement) {
+        floatingElement.parentNode.removeChild(floatingElement);
       }
 
-      // when it's the first step of tour
-      if (this._currentStep === 0 && this._introItems.length > 1) {
-        if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
-          skipTooltipButton.className = 'introjs-button introjs-skipbutton';
-        }
-        if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
-          nextTooltipButton.className = 'introjs-button introjs-nextbutton';
-        }
+      _removeShowElement();
 
-        if (this._options.hidePrev === true) {
-          if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
-            prevTooltipButton.className = 'introjs-button introjs-prevbutton introjs-hidden';
-          }
-          if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
-            _addClass(nextTooltipButton, 'introjs-fullbutton');
-          }
-        } else {
-          if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
-            prevTooltipButton.className = 'introjs-button introjs-prevbutton introjs-disabled';
-          }
-        }
+      //remove `introjs-fixParent` class from the elements
+      var fixParents = document.querySelectorAll('.introjs-fixParent');
+      _forEach(fixParents, function (parent) {
+        _removeClass(parent, /introjs-fixParent/g);
+      });
 
-        if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
-          skipTooltipButton.innerHTML = this._options.skipLabel;
-        }
-      } else if (this._introItems.length - 1 === this._currentStep || this._introItems.length === 1) {
-        // last step of tour
-        if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
-          skipTooltipButton.innerHTML = this._options.doneLabel;
-          // adding donebutton class in addition to skipbutton
-          _addClass(skipTooltipButton, 'introjs-donebutton');
-        }
-        if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
-          prevTooltipButton.className = 'introjs-button introjs-prevbutton';
-        }
-
-        if (this._options.hideNext === true) {
-          if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
-            nextTooltipButton.className = 'introjs-button introjs-nextbutton introjs-hidden';
-          }
-          if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
-            _addClass(prevTooltipButton, 'introjs-fullbutton');
-          }
-        } else {
-          if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
-            nextTooltipButton.className = 'introjs-button introjs-nextbutton introjs-disabled';
-          }
-        }
-      } else {
-        // steps between start and end
-        if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
-          skipTooltipButton.className = 'introjs-button introjs-skipbutton';
-        }
-        if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
-          prevTooltipButton.className = 'introjs-button introjs-prevbutton';
-        }
-        if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
-          nextTooltipButton.className = 'introjs-button introjs-nextbutton';
-        }
-        if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
-          skipTooltipButton.innerHTML = this._options.skipLabel;
-        }
+      //clean listeners
+      if (window.removeEventListener) {
+        window.removeEventListener('keydown', this._onKeyDown, true);
+      } else if (document.detachEvent) { //IE
+        document.detachEvent('onkeydown', this._onKeyDown);
       }
 
-      prevTooltipButton.setAttribute('role', 'button');
-      nextTooltipButton.setAttribute('role', 'button');
-      skipTooltipButton.setAttribute('role', 'button');
-
-      //Set focus on "next" button, so that hitting Enter always moves you onto the next step
-      if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
-        nextTooltipButton.focus();
-      }
-
-      _setShowElement(targetElement);
-
-      // Call event handlers for 'afterChange'.
-      _executeEventListeners.call(this, EVENT_NAMES.afterChange, null, targetElement.element).then(
-        function () {
-          _setLayerOpacity(1);
-          // unblock user interaction
-          this._blockUserInteraction = false;
-        }.bind(this)
-      ).catch(
-        function(blockEvents) {
-          _failIntro.call(this, blockEvents);
-        }.bind(this)
-      );
-    }.bind(this),
-    function(blockEvents) {
-      _failIntro.call(this, blockEvents);
-    }.bind(this)
-  );
-}
-
-/**
- * To change the scroll of `window` after highlighting an element
- *
- * @api private
- * @method _scrollTo
- * @param {String} scrollTo
- * @param {Object} targetElement
- * @param {Object} tooltipLayer
- */
-function _scrollTo(scrollTo, targetElement, tooltipLayer) {
-  if (scrollTo === 'off') return;  
-  var rect;
-
-  if (!this._options.scrollToElement) return;
-
-  if (scrollTo === 'tooltip') {
-    rect = tooltipLayer.getBoundingClientRect();
-  } else {
-    rect = targetElement.element.getBoundingClientRect();
+      _executeEventListeners.call(this, EVENT_NAMES.exit, null).then(function() {
+        //set the step to zero
+        this._currentStep = undefined;
+        this._blockEventHandling = false;
+      }.bind(this));
+    }.bind(this));
   }
 
-  if (!_elementInViewport(targetElement.element)) {
-    var winHeight = _getWinSize().height;
-    var top = rect.bottom - (rect.bottom - rect.top);
+  /**
+   * Render tooltip box in the page
+   *
+   * @api private
+   * @method _placeTooltip
+   * @param {HTMLElement} targetElement
+   * @param {HTMLElement} tooltipLayer
+   * @param {HTMLElement} arrowLayer
+   * @param {HTMLElement} helperNumberLayer
+   * @param {Boolean} hintMode
+   */
+  function _placeTooltip(targetElement, tooltipLayer, arrowLayer, helperNumberLayer, hintMode) {
+    var tooltipCssClass = '',
+        currentStepObj,
+        tooltipOffset,
+        targetOffset,
+        windowSize,
+        currentTooltipPosition;
 
-    // TODO (afshinm): do we need scroll padding now?
-    // I have changed the scroll option and now it scrolls the window to
-    // the center of the target element or tooltip.
+    hintMode = hintMode || false;
 
-    if (top < 0 || targetElement.element.clientHeight > winHeight) {
-      window.scrollBy(0, rect.top - ((winHeight / 2) -  (rect.height / 2)) - this._options.scrollPadding); // 30px padding from edge to look nice
+    //reset the old style
+    tooltipLayer.style.top        = null;
+    tooltipLayer.style.right      = null;
+    tooltipLayer.style.bottom     = null;
+    tooltipLayer.style.left       = null;
+    tooltipLayer.style.marginLeft = null;
+    tooltipLayer.style.marginTop  = null;
 
-    //Scroll down
+    arrowLayer.style.display = 'inherit';
+
+    if (typeof(helperNumberLayer) !== 'undefined' && helperNumberLayer !== null) {
+      helperNumberLayer.style.top  = null;
+      helperNumberLayer.style.left = null;
+    }
+
+    //prevent error when `this._currentStep` is undefined
+    if (!this._introItems[this._currentStep]) return;
+
+    //if we have a custom css class for each step
+    currentStepObj = this._introItems[this._currentStep];
+    if (typeof (currentStepObj.tooltipClass) === 'string') {
+      tooltipCssClass = currentStepObj.tooltipClass;
     } else {
-      window.scrollBy(0, rect.top - ((winHeight / 2) -  (rect.height / 2)) + this._options.scrollPadding); // 30px padding from edge to look nice
+      tooltipCssClass = this._options.tooltipClass;
+    }
+
+    tooltipLayer.className = ('introjs-tooltip ' + tooltipCssClass).replace(/^\s+|\s+$/g, '');
+    tooltipLayer.setAttribute('role', 'dialog');
+
+    currentTooltipPosition = this._introItems[this._currentStep].position;
+
+    // Floating is always valid, no point in calculating
+    if (currentTooltipPosition !== "floating") { 
+      currentTooltipPosition = _determineAutoPosition.call(this, targetElement, tooltipLayer, currentTooltipPosition);
+    }
+
+    var tooltipLayerStyleLeft;
+    targetOffset  = _getOffset(targetElement);
+    tooltipOffset = _getOffset(tooltipLayer);
+    windowSize    = _getWinSize();
+
+    _addClass(tooltipLayer, 'introjs-' + currentTooltipPosition);
+
+    switch (currentTooltipPosition) {
+      case 'top-right-aligned':
+        arrowLayer.className      = 'introjs-arrow bottom-right';
+
+        var tooltipLayerStyleRight = 0;
+        _checkLeft(targetOffset, tooltipLayerStyleRight, tooltipOffset, tooltipLayer);
+        tooltipLayer.style.bottom    = (targetOffset.height +  20) + 'px';
+        break;
+
+      case 'top-middle-aligned':
+        arrowLayer.className      = 'introjs-arrow bottom-middle';
+
+        var tooltipLayerStyleLeftRight = targetOffset.width / 2 - tooltipOffset.width / 2;
+
+        // a fix for middle aligned hints
+        if (hintMode) {
+          tooltipLayerStyleLeftRight += 5;
+        }
+
+        if (_checkLeft(targetOffset, tooltipLayerStyleLeftRight, tooltipOffset, tooltipLayer)) {
+          tooltipLayer.style.right = null;
+          _checkRight(targetOffset, tooltipLayerStyleLeftRight, tooltipOffset, windowSize, tooltipLayer);
+        }
+        tooltipLayer.style.bottom = (targetOffset.height + 20) + 'px';
+        break;
+
+      case 'top-left-aligned':
+      // top-left-aligned is the same as the default top
+      case 'top':
+        arrowLayer.className = 'introjs-arrow bottom';
+
+        tooltipLayerStyleLeft = (hintMode) ? 0 : 15;
+
+        _checkRight(targetOffset, tooltipLayerStyleLeft, tooltipOffset, windowSize, tooltipLayer);
+        tooltipLayer.style.bottom = (targetOffset.height +  20) + 'px';
+        break;
+      case 'right':
+        tooltipLayer.style.left = (targetOffset.width + 20) + 'px';
+        if (targetOffset.top + tooltipOffset.height > windowSize.height) {
+          // In this case, right would have fallen below the bottom of the screen.
+          // Modify so that the bottom of the tooltip connects with the target
+          arrowLayer.className = "introjs-arrow left-bottom";
+          tooltipLayer.style.top = "-" + (tooltipOffset.height - targetOffset.height - 20) + "px";
+        } else {
+          arrowLayer.className = 'introjs-arrow left';
+        }
+        break;
+      case 'left':
+        if (!hintMode && this._options.showStepNumbers === true) {
+          tooltipLayer.style.top = '15px';
+        }
+
+        if (targetOffset.top + tooltipOffset.height > windowSize.height) {
+          // In this case, left would have fallen below the bottom of the screen.
+          // Modify so that the bottom of the tooltip connects with the target
+          tooltipLayer.style.top = "-" + (tooltipOffset.height - targetOffset.height - 20) + "px";
+          arrowLayer.className = 'introjs-arrow right-bottom';
+        } else {
+          arrowLayer.className = 'introjs-arrow right';
+        }
+        tooltipLayer.style.right = (targetOffset.width + 20) + 'px';
+
+        break;
+      case 'floating':
+        arrowLayer.style.display = 'none';
+
+        //we have to adjust the top and left of layer manually for intro items without element
+        tooltipLayer.style.left   = '50%';
+        tooltipLayer.style.top    = '50%';
+        tooltipLayer.style.marginLeft = '-' + (tooltipOffset.width / 2)  + 'px';
+        tooltipLayer.style.marginTop  = '-' + (tooltipOffset.height / 2) + 'px';
+
+        if (typeof(helperNumberLayer) !== 'undefined' && helperNumberLayer !== null) {
+          helperNumberLayer.style.left = '-' + ((tooltipOffset.width / 2) + 18) + 'px';
+          helperNumberLayer.style.top  = '-' + ((tooltipOffset.height / 2) + 18) + 'px';
+        }
+
+        break;
+      case 'bottom-right-aligned':
+        arrowLayer.className      = 'introjs-arrow top-right';
+
+        tooltipLayerStyleRight = 0;
+        _checkLeft(targetOffset, tooltipLayerStyleRight, tooltipOffset, tooltipLayer);
+        tooltipLayer.style.top    = (targetOffset.height +  20) + 'px';
+        break;
+
+      case 'bottom-middle-aligned':
+        arrowLayer.className      = 'introjs-arrow top-middle';
+
+        tooltipLayerStyleLeftRight = targetOffset.width / 2 - tooltipOffset.width / 2;
+
+        // a fix for middle aligned hints
+        if (hintMode) {
+          tooltipLayerStyleLeftRight += 5;
+        }
+
+        if (_checkLeft(targetOffset, tooltipLayerStyleLeftRight, tooltipOffset, tooltipLayer)) {
+          tooltipLayer.style.right = null;
+          _checkRight(targetOffset, tooltipLayerStyleLeftRight, tooltipOffset, windowSize, tooltipLayer);
+        }
+        tooltipLayer.style.top = (targetOffset.height + 20) + 'px';
+        break;
+
+      // case 'bottom-left-aligned':
+      // Bottom-left-aligned is the same as the default bottom
+      // case 'bottom':
+      // Bottom going to follow the default behavior
+      default:
+        arrowLayer.className = 'introjs-arrow top';
+
+        tooltipLayerStyleLeft = 0;
+        _checkRight(targetOffset, tooltipLayerStyleLeft, tooltipOffset, windowSize, tooltipLayer);
+        tooltipLayer.style.top    = (targetOffset.height +  20) + 'px';
     }
   }
-}
 
-/**
- * To remove all show element(s)
- *
- * @api private
- * @method _removeShowElement
- */
-function _removeShowElement() {
-  var elms = document.querySelectorAll('.introjs-showElement');
+  /**
+   * Set tooltip left so it doesn't go off the right side of the window
+   *
+   * @return boolean true, if tooltipLayerStyleLeft is ok.  false, otherwise.
+   */
+  function _checkRight(targetOffset, tooltipLayerStyleLeft, tooltipOffset, windowSize, tooltipLayer) {
+    if (targetOffset.left + tooltipLayerStyleLeft + tooltipOffset.width > windowSize.width) {
+      // off the right side of the window
+      tooltipLayer.style.left = (windowSize.width - tooltipOffset.width - targetOffset.left) + 'px';
+      return false;
+    }
+    tooltipLayer.style.left = tooltipLayerStyleLeft + 'px';
+    return true;
+  }
 
-  _forEach(elms, function (elm) {
-    _removeClass(elm, /introjs-[a-zA-Z]+/g);
-  });
-}
+  /**
+   * Set tooltip right so it doesn't go off the left side of the window
+   *
+   * @return boolean true, if tooltipLayerStyleRight is ok.  false, otherwise.
+   */
+  function _checkLeft(targetOffset, tooltipLayerStyleRight, tooltipOffset, tooltipLayer) {
+    if (targetOffset.left + targetOffset.width - tooltipLayerStyleRight - tooltipOffset.width < 0) {
+      // off the left side of the window
+      tooltipLayer.style.left = (-targetOffset.left) + 'px';
+      return false;
+    }
+    tooltipLayer.style.right = tooltipLayerStyleRight + 'px';
+    return true;
+  }
 
-/**
- * To set the show element
- * This function set a relative (in most cases) position and changes the z-index
- *
- * @api private
- * @method _setShowElement
- * @param {Object} targetElement
- */
-function _setShowElement(targetElement) {
-  var parentElm;
-  // we need to add this show element class to the parent of SVG elements
-  // because the SVG elements can't have independent z-index
-  if (targetElement.element instanceof SVGElement) {
+  /**
+   * Determines the position of the tooltip based on the position precedence and availability
+   * of screen space.
+   *
+   * @param {Object}    targetElement
+   * @param {Object}    tooltipLayer
+   * @param {String}    desiredTooltipPosition
+   * @return {String}   calculatedPosition
+   */
+  function _determineAutoPosition(targetElement, tooltipLayer, desiredTooltipPosition) {
+
+    // Take a clone of position precedence. These will be the available
+    var possiblePositions = this._options.positionPrecedence.slice();
+
+    var windowSize = _getWinSize();
+    var tooltipHeight = _getOffset(tooltipLayer).height + 10;
+    var tooltipWidth = _getOffset(tooltipLayer).width + 20;
+    var targetElementRect = targetElement.getBoundingClientRect();
+
+    // If we check all the possible areas, and there are no valid places for the tooltip, the element
+    // must take up most of the screen real estate. Show the tooltip floating in the middle of the screen.
+    var calculatedPosition = "floating";
+
+    /*
+    * auto determine position 
+    */
+
+    // Check for space below
+    if (targetElementRect.bottom + tooltipHeight + tooltipHeight > windowSize.height) {
+      _removeEntry(possiblePositions, "bottom");
+    }
+
+    // Check for space above
+    if (targetElementRect.top - tooltipHeight < 0) {
+      _removeEntry(possiblePositions, "top");
+    }
+
+    // Check for space to the right
+    if (targetElementRect.right + tooltipWidth > windowSize.width) {
+      _removeEntry(possiblePositions, "right");
+    }
+
+    // Check for space to the left
+    if (targetElementRect.left - tooltipWidth < 0) {
+      _removeEntry(possiblePositions, "left");
+    }
+
+    // @var {String}  ex: 'right-aligned'
+    var desiredAlignment = (function (pos) {
+      var hyphenIndex = pos.indexOf('-');
+      if (hyphenIndex !== -1) {
+        // has alignment
+        return pos.substr(hyphenIndex);
+      }
+      return '';
+    })(desiredTooltipPosition || '');
+
+    // strip alignment from position
+    if (desiredTooltipPosition) {
+      // ex: "bottom-right-aligned"
+      // should return 'bottom'
+      desiredTooltipPosition = desiredTooltipPosition.split('-')[0];
+    }
+
+    if (possiblePositions.length) {
+      if (desiredTooltipPosition !== "auto" &&
+          possiblePositions.indexOf(desiredTooltipPosition) > -1) {
+        // If the requested position is in the list, choose that
+        calculatedPosition = desiredTooltipPosition;
+      } else {
+        // Pick the first valid position, in order
+        calculatedPosition = possiblePositions[0];
+      }
+    }
+
+    // only top and bottom positions have optional alignments
+    if (['top', 'bottom'].indexOf(calculatedPosition) !== -1) {
+      calculatedPosition += _determineAutoAlignment(targetElementRect.left, tooltipWidth, windowSize, desiredAlignment);
+    }
+
+    return calculatedPosition;
+  }
+
+  /**
+  * auto-determine alignment
+  * @param {Integer}  offsetLeft
+  * @param {Integer}  tooltipWidth
+  * @param {Object}   windowSize
+  * @param {String}   desiredAlignment
+  * @return {String}  calculatedAlignment
+  */
+  function _determineAutoAlignment (offsetLeft, tooltipWidth, windowSize, desiredAlignment) {
+    var halfTooltipWidth = tooltipWidth / 2,
+      winWidth = Math.min(windowSize.width, window.screen.width),
+      possibleAlignments = ['-left-aligned', '-middle-aligned', '-right-aligned'],
+      calculatedAlignment = '';
+    
+    // valid left must be at least a tooltipWidth
+    // away from right side
+    if (winWidth - offsetLeft < tooltipWidth) {
+      _removeEntry(possibleAlignments, '-left-aligned');
+    }
+
+    // valid middle must be at least half 
+    // width away from both sides
+    if (offsetLeft < halfTooltipWidth || 
+      winWidth - offsetLeft < halfTooltipWidth) {
+      _removeEntry(possibleAlignments, '-middle-aligned');
+    }
+
+    // valid right must be at least a tooltipWidth
+    // width away from left side
+    if (offsetLeft < tooltipWidth) {
+      _removeEntry(possibleAlignments, '-right-aligned');
+    }
+
+    if (possibleAlignments.length) {
+      if (possibleAlignments.indexOf(desiredAlignment) !== -1) {
+        // the desired alignment is valid
+        calculatedAlignment = desiredAlignment;
+      } else {
+        // pick the first valid position, in order
+        calculatedAlignment = possibleAlignments[0];
+      }
+    } else {
+      // if screen width is too small 
+      // for ANY alignment, middle is 
+      // probably the best for visibility
+      calculatedAlignment = '-middle-aligned';
+    }
+
+    return calculatedAlignment;
+  }
+
+  /**
+   * Remove an entry from a string array if it's there, does nothing if it isn't there.
+   *
+   * @param {Array} stringArray
+   * @param {String} stringToRemove
+   */
+  function _removeEntry(stringArray, stringToRemove) {
+    if (stringArray.indexOf(stringToRemove) > -1) {
+      stringArray.splice(stringArray.indexOf(stringToRemove), 1);
+    }
+  }
+
+  /**
+   * Update the position of the helper layer on the screen
+   *
+   * @api private
+   * @method _setHelperLayerPosition
+   * @param {Object} helperLayer
+   */
+  function _setHelperLayerPosition(helperLayer) {
+    if (helperLayer) {
+      //prevent error when `this._currentStep` in undefined
+      if (!this._introItems[this._currentStep]) return;
+
+      var currentElement  = this._introItems[this._currentStep],
+          elementPosition = _getOffset(currentElement.element),
+          widthHeightPadding = this._options.helperElementPadding;
+
+      // If the target element is fixed, the tooltip should be fixed as well.
+      // Otherwise, remove a fixed class that may be left over from the previous
+      // step.
+      if (_isFixed(currentElement.element)) {
+        _addClass(helperLayer, 'introjs-fixedTooltip');
+      } else {
+        _removeClass(helperLayer, 'introjs-fixedTooltip');
+      }
+
+      if (currentElement.position === 'floating') {
+        widthHeightPadding = 0;
+      }
+
+      //set new position to helper layer
+      helperLayer.setAttribute('style', 'width: ' + (elementPosition.width  + widthHeightPadding)  + 'px; ' +
+                                        'height:' + (elementPosition.height + widthHeightPadding)  + 'px; ' +
+                                        'top:'    + (elementPosition.top    - widthHeightPadding / 2)   + 'px;' +
+                                        'left: '  + (elementPosition.left   - widthHeightPadding / 2)   + 'px;');
+
+    }
+  }
+
+  /**
+   * Add disableinteraction layer and adjust the size and position of the layer
+   *
+   * @api private
+   * @method _disableInteraction
+   */
+  function _disableInteraction() {
+    var disableInteractionLayer = document.querySelector('.introjs-disableInteraction');
+
+    if (disableInteractionLayer === null) {
+      disableInteractionLayer = document.createElement('div');
+      disableInteractionLayer.className = 'introjs-disableInteraction';
+      this._targetElement.appendChild(disableInteractionLayer);
+    }
+
+    _setHelperLayerPosition.call(this, disableInteractionLayer);
+  }
+
+  /**
+   * Setting anchors to behave like buttons
+   *
+   * @api private
+   * @method _setAnchorAsButton
+   */
+  function _setAnchorAsButton(anchor){
+    anchor.setAttribute('role', 'button');
+    anchor.tabIndex = 0;
+  }
+
+  /**
+   * Show an element on the page
+   *
+   * @api private
+   * @method _showElement
+   * @param {Object} targetElement
+   */
+  function _showElement(targetElement) {
+    _executeEventListeners.call(this, EVENT_NAMES.change, null, targetElement.element).then(
+      function() {
+        var self = this,
+            oldHelperLayer = document.querySelector('.introjs-helperLayer'),
+            oldReferenceLayer = document.querySelector('.introjs-tooltipReferenceLayer'),
+            highlightClass = 'introjs-helperLayer',
+            nextTooltipButton,
+            prevTooltipButton,
+            skipTooltipButton;
+
+        //check for a current step highlight class
+        if (typeof (targetElement.highlightClass) === 'string') {
+          highlightClass += (' ' + targetElement.highlightClass);
+        }
+        //check for options highlight class
+        if (typeof (this._options.highlightClass) === 'string') {
+          highlightClass += (' ' + this._options.highlightClass);
+        }
+
+        if (oldHelperLayer !== null) {
+          var oldHelperNumberLayer = oldReferenceLayer.querySelector('.introjs-helperNumberLayer'),
+              oldtooltipLayer      = oldReferenceLayer.querySelector('.introjs-tooltiptext'),
+              oldArrowLayer        = oldReferenceLayer.querySelector('.introjs-arrow'),
+              oldtooltipContainer  = oldReferenceLayer.querySelector('.introjs-tooltip');
+              
+          skipTooltipButton    = oldReferenceLayer.querySelector('.introjs-skipbutton');
+          prevTooltipButton    = oldReferenceLayer.querySelector('.introjs-prevbutton');
+          nextTooltipButton    = oldReferenceLayer.querySelector('.introjs-nextbutton');
+
+          //update or reset the helper highlight class
+          oldHelperLayer.className = highlightClass;
+          //hide the tooltip
+          oldtooltipContainer.style.opacity = 0;
+          oldtooltipContainer.style.display = "none";
+
+          if (oldHelperNumberLayer !== null) {
+            var lastIntroItem = this._introItems[(targetElement.step - 2 >= 0 ? targetElement.step - 2 : 0)];
+
+            if (lastIntroItem !== null && (this._direction === 'forward' && lastIntroItem.position === 'floating') || (this._direction === 'backward' && targetElement.position === 'floating')) {
+              oldHelperNumberLayer.style.opacity = 0;
+            }
+          }
+
+          //set new position to helper layer
+          _setHelperLayerPosition.call(self, oldHelperLayer);
+          _setHelperLayerPosition.call(self, oldReferenceLayer);
+
+          //remove `introjs-fixParent` class from the elements
+          var fixParents = document.querySelectorAll('.introjs-fixParent');
+          _forEach(fixParents, function (parent) {
+            _removeClass(parent, /introjs-fixParent/g);
+          });
+          
+          //remove old classes if the element still exist
+          _removeShowElement();
+
+          //we should wait until the CSS3 transition is competed (it's 0.3 sec) to prevent incorrect `height` and `width` calculation
+          if (self._lastShowElementTimer) {
+            window.clearTimeout(self._lastShowElementTimer);
+          }
+
+          self._lastShowElementTimer = window.setTimeout(function() {
+            //set current step to the label
+            if (oldHelperNumberLayer !== null) {
+              oldHelperNumberLayer.innerHTML = targetElement.step;
+            }
+            //set current tooltip text
+            oldtooltipLayer.innerHTML = targetElement.intro;
+            //set the tooltip position
+            oldtooltipContainer.style.display = "block";
+            _placeTooltip.call(self, targetElement.element, oldtooltipContainer, oldArrowLayer, oldHelperNumberLayer);
+
+            //change active bullet
+            if (self._options.showBullets) {
+                oldReferenceLayer.querySelector('.introjs-bullets li > a.active').className = '';
+                oldReferenceLayer.querySelector('.introjs-bullets li > a[data-stepnumber="' + targetElement.step + '"]').className = 'active';
+            }
+            oldReferenceLayer.querySelector('.introjs-progress .introjs-progressbar').setAttribute('style', 'width:' + _getProgress.call(self) + '%;');
+            oldReferenceLayer.querySelector('.introjs-progress .introjs-progressbar').setAttribute('aria-valuenow', _getProgress.call(self));
+
+            //show the tooltip
+            oldtooltipContainer.style.opacity = 1;
+            if (oldHelperNumberLayer) oldHelperNumberLayer.style.opacity = 1;
+
+            //reset button focus
+            if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null && /introjs-donebutton/gi.test(skipTooltipButton.className)) {
+              // skip button is now "done" button
+              skipTooltipButton.focus();
+            } else if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
+              //still in the tour, focus on next
+              nextTooltipButton.focus();
+            }
+
+            // change the scroll of the window, if needed
+            _scrollTo.call(self, targetElement.scrollTo, targetElement, oldtooltipLayer);
+          }, 350);
+
+          // end of old element if-else condition
+        } else {
+          var helperLayer       = document.createElement('div'),
+              referenceLayer    = document.createElement('div'),
+              arrowLayer        = document.createElement('div'),
+              tooltipLayer      = document.createElement('div'),
+              tooltipTextLayer  = document.createElement('div'),
+              bulletsLayer      = document.createElement('div'),
+              progressLayer     = document.createElement('div'),
+              buttonsLayer      = document.createElement('div');
+
+          helperLayer.className = highlightClass;
+          referenceLayer.className = 'introjs-tooltipReferenceLayer';
+
+          //set new position to helper layer
+          _setHelperLayerPosition.call(self, helperLayer);
+          _setHelperLayerPosition.call(self, referenceLayer);
+
+          //add helper layer to target element
+          this._targetElement.appendChild(helperLayer);
+          this._targetElement.appendChild(referenceLayer);
+
+          arrowLayer.className = 'introjs-arrow';
+
+          tooltipTextLayer.className = 'introjs-tooltiptext';
+          tooltipTextLayer.innerHTML = targetElement.intro;
+
+          bulletsLayer.className = 'introjs-bullets';
+
+          if (this._options.showBullets === false) {
+            bulletsLayer.style.display = 'none';
+          }
+
+          var ulContainer = document.createElement('ul');
+          ulContainer.setAttribute('role', 'tablist');
+
+          var anchorClick = function () {
+              if (self._blockUserInteraction) return;
+              self.goToStep(this.getAttribute('data-stepnumber'));
+          };
+
+          _forEach(this._introItems, function (item, i) {
+            var innerLi    = document.createElement('li');
+            var anchorLink = document.createElement('a');
+            
+            innerLi.setAttribute('role', 'presentation');
+            anchorLink.setAttribute('role', 'tab');
+
+            anchorLink.onclick = anchorClick;
+
+            if (i === (targetElement.step-1)) {
+              anchorLink.className = 'active';
+            } 
+
+            _setAnchorAsButton(anchorLink);
+            anchorLink.innerHTML = "&nbsp;";
+            anchorLink.setAttribute('data-stepnumber', item.step);
+
+            innerLi.appendChild(anchorLink);
+            ulContainer.appendChild(innerLi);
+          });
+
+          bulletsLayer.appendChild(ulContainer);
+
+          progressLayer.className = 'introjs-progress';
+
+          if (this._options.showProgress === false) {
+            progressLayer.style.display = 'none';
+          }
+          var progressBar = document.createElement('div');
+          progressBar.className = 'introjs-progressbar';
+          progressBar.setAttribute('role', 'progress');
+          progressBar.setAttribute('aria-valuemin', 0);
+          progressBar.setAttribute('aria-valuemax', 100);
+          progressBar.setAttribute('aria-valuenow', _getProgress.call(this));
+          progressBar.setAttribute('style', 'width:' + _getProgress.call(this) + '%;');
+
+          progressLayer.appendChild(progressBar);
+
+          buttonsLayer.className = 'introjs-tooltipbuttons';
+          if (this._options.showButtons === false) {
+            buttonsLayer.style.display = 'none';
+          }
+
+          tooltipLayer.className = 'introjs-tooltip';
+          tooltipLayer.appendChild(tooltipTextLayer);
+          tooltipLayer.appendChild(bulletsLayer);
+          tooltipLayer.appendChild(progressLayer);
+
+          //add helper layer number
+          var helperNumberLayer = document.createElement('span');
+          if (this._options.showStepNumbers === true) {
+            helperNumberLayer.className = 'introjs-helperNumberLayer';
+            helperNumberLayer.innerHTML = targetElement.step;
+            referenceLayer.appendChild(helperNumberLayer);
+          }
+
+          tooltipLayer.appendChild(arrowLayer);
+          referenceLayer.appendChild(tooltipLayer);
+
+          //next button
+          nextTooltipButton = document.createElement('a');
+
+          nextTooltipButton.onclick = function() {
+            if (self._blockUserInteraction) return;
+            if (self._introItems.length - 1 !== self._currentStep) {
+              _nextStep.call(self);
+            }
+          };
+
+          _setAnchorAsButton(nextTooltipButton);
+          nextTooltipButton.innerHTML = this._options.nextLabel;
+
+          //previous button
+          prevTooltipButton = document.createElement('a');
+
+          prevTooltipButton.onclick = function() {
+            if (self._blockUserInteraction) return;
+            if (self._currentStep !== 0) {
+              _previousStep.call(self);
+            }
+          };
+
+          _setAnchorAsButton(prevTooltipButton);
+          prevTooltipButton.innerHTML = this._options.prevLabel;
+
+          //skip button
+          skipTooltipButton = document.createElement('a');
+          skipTooltipButton.className = 'introjs-button introjs-skipbutton';
+          _setAnchorAsButton(skipTooltipButton);
+          skipTooltipButton.innerHTML = this._options.skipLabel;
+
+          skipTooltipButton.onclick = function() {
+            if (self._blockUserInteraction) return;
+            if (self._introItems.length - 1 === self._currentStep) {
+              _executeEventListeners.call(self, EVENT_NAMES.complete, null).then(function() {
+                _exitIntro.call(self, self._targetElement);
+              });
+            } else {
+              _exitIntro.call(self, self._targetElement);
+            }
+          };
+
+          buttonsLayer.appendChild(skipTooltipButton);
+
+          //in order to prevent displaying next/previous button always
+          if (this._introItems.length > 1) {
+            buttonsLayer.appendChild(prevTooltipButton);
+            buttonsLayer.appendChild(nextTooltipButton);
+          }
+
+          tooltipLayer.appendChild(buttonsLayer);
+
+          //set proper position
+          _placeTooltip.call(self, targetElement.element, tooltipLayer, arrowLayer, helperNumberLayer);
+
+          // change the scroll of the window, if needed
+          _scrollTo.call(this, targetElement.scrollTo, targetElement, tooltipLayer);
+
+          //end of new element if-else condition
+        }
+
+        // removing previous disable interaction layer
+        var disableInteractionLayer = self._targetElement.querySelector('.introjs-disableInteraction');
+        if (disableInteractionLayer) {
+          disableInteractionLayer.parentNode.removeChild(disableInteractionLayer);
+        }
+
+        //disable interaction
+        if (targetElement.disableInteraction) {
+          _disableInteraction.call(self);
+        }
+
+        // when it's the first step of tour
+        if (this._currentStep === 0 && this._introItems.length > 1) {
+          if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
+            skipTooltipButton.className = 'introjs-button introjs-skipbutton';
+          }
+          if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
+            nextTooltipButton.className = 'introjs-button introjs-nextbutton';
+          }
+
+          if (this._options.hidePrev === true) {
+            if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
+              prevTooltipButton.className = 'introjs-button introjs-prevbutton introjs-hidden';
+            }
+            if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
+              _addClass(nextTooltipButton, 'introjs-fullbutton');
+            }
+          } else {
+            if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
+              prevTooltipButton.className = 'introjs-button introjs-prevbutton introjs-disabled';
+            }
+          }
+
+          if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
+            skipTooltipButton.innerHTML = this._options.skipLabel;
+          }
+        } else if (this._introItems.length - 1 === this._currentStep || this._introItems.length === 1) {
+          // last step of tour
+          if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
+            skipTooltipButton.innerHTML = this._options.doneLabel;
+            // adding donebutton class in addition to skipbutton
+            _addClass(skipTooltipButton, 'introjs-donebutton');
+          }
+          if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
+            prevTooltipButton.className = 'introjs-button introjs-prevbutton';
+          }
+
+          if (this._options.hideNext === true) {
+            if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
+              nextTooltipButton.className = 'introjs-button introjs-nextbutton introjs-hidden';
+            }
+            if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
+              _addClass(prevTooltipButton, 'introjs-fullbutton');
+            }
+          } else {
+            if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
+              nextTooltipButton.className = 'introjs-button introjs-nextbutton introjs-disabled';
+            }
+          }
+        } else {
+          // steps between start and end
+          if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
+            skipTooltipButton.className = 'introjs-button introjs-skipbutton';
+          }
+          if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
+            prevTooltipButton.className = 'introjs-button introjs-prevbutton';
+          }
+          if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
+            nextTooltipButton.className = 'introjs-button introjs-nextbutton';
+          }
+          if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
+            skipTooltipButton.innerHTML = this._options.skipLabel;
+          }
+        }
+
+        prevTooltipButton.setAttribute('role', 'button');
+        nextTooltipButton.setAttribute('role', 'button');
+        skipTooltipButton.setAttribute('role', 'button');
+
+        //Set focus on "next" button, so that hitting Enter always moves you onto the next step
+        if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
+          nextTooltipButton.focus();
+        }
+
+        _setShowElement(targetElement);
+
+        // Call event handlers for 'afterChange'.
+        _executeEventListeners.call(this, EVENT_NAMES.afterChange, null, targetElement.element).then(
+          function () {
+            _setLayerOpacity(1);
+            // unblock user interaction
+            this._blockUserInteraction = false;
+          }.bind(this)
+        ).catch(
+          function(blockEvents) {
+            _failIntro.call(this, blockEvents);
+          }.bind(this)
+        );
+      }.bind(this),
+      function(blockEvents) {
+        _failIntro.call(this, blockEvents);
+      }.bind(this)
+    );
+  }
+
+  /**
+   * To change the scroll of `window` after highlighting an element
+   *
+   * @api private
+   * @method _scrollTo
+   * @param {String} scrollTo
+   * @param {Object} targetElement
+   * @param {Object} tooltipLayer
+   */
+  function _scrollTo(scrollTo, targetElement, tooltipLayer) {
+    if (scrollTo === 'off') return;  
+    var rect;
+
+    if (!this._options.scrollToElement) return;
+
+    if (scrollTo === 'tooltip') {
+      rect = tooltipLayer.getBoundingClientRect();
+    } else {
+      rect = targetElement.element.getBoundingClientRect();
+    }
+
+    if (!_elementInViewport(targetElement.element)) {
+      var winHeight = _getWinSize().height;
+      var top = rect.bottom - (rect.bottom - rect.top);
+
+      // TODO (afshinm): do we need scroll padding now?
+      // I have changed the scroll option and now it scrolls the window to
+      // the center of the target element or tooltip.
+
+      if (top < 0 || targetElement.element.clientHeight > winHeight) {
+        window.scrollBy(0, rect.top - ((winHeight / 2) -  (rect.height / 2)) - this._options.scrollPadding); // 30px padding from edge to look nice
+
+      //Scroll down
+      } else {
+        window.scrollBy(0, rect.top - ((winHeight / 2) -  (rect.height / 2)) + this._options.scrollPadding); // 30px padding from edge to look nice
+      }
+    }
+  }
+
+  /**
+   * To remove all show element(s)
+   *
+   * @api private
+   * @method _removeShowElement
+   */
+  function _removeShowElement() {
+    var elms = document.querySelectorAll('.introjs-showElement');
+
+    _forEach(elms, function (elm) {
+      _removeClass(elm, /introjs-[a-zA-Z]+/g);
+    });
+  }
+
+  /**
+   * To set the show element
+   * This function set a relative (in most cases) position and changes the z-index
+   *
+   * @api private
+   * @method _setShowElement
+   * @param {Object} targetElement
+   */
+  function _setShowElement(targetElement) {
+    var parentElm;
+    // we need to add this show element class to the parent of SVG elements
+    // because the SVG elements can't have independent z-index
+    if (targetElement.element instanceof SVGElement) {
+      parentElm = targetElement.element.parentNode;
+
+      while (targetElement.element.parentNode !== null) {
+        if (!parentElm.tagName || parentElm.tagName.toLowerCase() === 'body') break;
+
+        if (parentElm.tagName.toLowerCase() === 'svg') {
+          _addClass(parentElm, 'introjs-showElement introjs-relativePosition');
+        }
+
+        parentElm = parentElm.parentNode;
+      }
+    }
+
+    _addClass(targetElement.element, 'introjs-showElement');
+
+    var currentElementPosition = _getPropValue(targetElement.element, 'position');
+    if (currentElementPosition !== 'absolute' &&
+        currentElementPosition !== 'relative' &&
+        currentElementPosition !== 'fixed') {
+      //change to new intro item
+      _addClass(targetElement.element, 'introjs-relativePosition');
+    }
+
     parentElm = targetElement.element.parentNode;
-
-    while (targetElement.element.parentNode !== null) {
+    while (parentElm !== null) {
       if (!parentElm.tagName || parentElm.tagName.toLowerCase() === 'body') break;
 
-      if (parentElm.tagName.toLowerCase() === 'svg') {
-        _addClass(parentElm, 'introjs-showElement introjs-relativePosition');
+      //fix The Stacking Context problem.
+      //More detail: https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Understanding_z_index/The_stacking_context
+      var zIndex = _getPropValue(parentElm, 'z-index');
+      var opacity = parseFloat(_getPropValue(parentElm, 'opacity'));
+      var transform = _getPropValue(parentElm, 'transform') || _getPropValue(parentElm, '-webkit-transform') || _getPropValue(parentElm, '-moz-transform') || _getPropValue(parentElm, '-ms-transform') || _getPropValue(parentElm, '-o-transform');
+      if (/[0-9]+/.test(zIndex) || opacity < 1 || (transform !== 'none' && transform !== undefined)) {
+        _addClass(parentElm, 'introjs-fixParent');
       }
 
       parentElm = parentElm.parentNode;
     }
   }
 
-  _addClass(targetElement.element, 'introjs-showElement');
-
-  var currentElementPosition = _getPropValue(targetElement.element, 'position');
-  if (currentElementPosition !== 'absolute' &&
-      currentElementPosition !== 'relative' &&
-      currentElementPosition !== 'fixed') {
-    //change to new intro item
-    _addClass(targetElement.element, 'introjs-relativePosition');
-  }
-
-  parentElm = targetElement.element.parentNode;
-  while (parentElm !== null) {
-    if (!parentElm.tagName || parentElm.tagName.toLowerCase() === 'body') break;
-
-    //fix The Stacking Context problem.
-    //More detail: https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Understanding_z_index/The_stacking_context
-    var zIndex = _getPropValue(parentElm, 'z-index');
-    var opacity = parseFloat(_getPropValue(parentElm, 'opacity'));
-    var transform = _getPropValue(parentElm, 'transform') || _getPropValue(parentElm, '-webkit-transform') || _getPropValue(parentElm, '-moz-transform') || _getPropValue(parentElm, '-ms-transform') || _getPropValue(parentElm, '-o-transform');
-    if (/[0-9]+/.test(zIndex) || opacity < 1 || (transform !== 'none' && transform !== undefined)) {
-      _addClass(parentElm, 'introjs-fixParent');
-    }
-
-    parentElm = parentElm.parentNode;
-  }
-}
-
-/**
-* Iterates arrays
-*
-* @param {Array} arr
-* @param {Function} forEachFnc
-* @param {Function} completeFnc
-* @return {Null}
-*/
-function _forEach(arr, forEachFnc, completeFnc) {
-  // in case arr is an empty query selector node list
-  if (arr) {
-    for (var i = 0, len = arr.length; i < len; i++) {
-      forEachFnc(arr[i], i);
-    }
-  }
-
-  if (typeof(completeFnc) === 'function') {
-    completeFnc();
-  }
-}
-
-/**
- * Append a class to an element
- *
- * @api private
- * @method _addClass
- * @param {Object} element
- * @param {String} className
- * @returns null
- */
-function _addClass(element, className) {
-  if (element instanceof SVGElement) {
-    // svg
-    var pre = element.getAttribute('class') || '';
-
-    element.setAttribute('class', pre + ' ' + className);
-  } else {
-    if (element.classList !== undefined) {
-      // check for modern classList property
-      var classes = className.split(' ');
-      _forEach(classes, function (cls) {
-        element.classList.add( cls );
-      });
-    } else if (!element.className.match( className )) {
-      // check if element doesn't already have className
-      element.className += ' ' + className;
-    }
-  }
-}
-
-/**
- * Remove a class from an element
- *
- * @api private
- * @method _removeClass
- * @param {Object} element
- * @param {RegExp|String} classNameRegex can be regex or string
- * @returns null
- */
-function _removeClass(element, classNameRegex) {
-  if (element instanceof SVGElement) {
-    var pre = element.getAttribute('class') || '';
-
-    element.setAttribute('class', pre.replace(classNameRegex, '').replace(/^\s+|\s+$/g, ''));
-  } else {
-    element.className = element.className.replace(classNameRegex, '').replace(/^\s+|\s+$/g, '');
-  }
-}
-
-/**
- * Get an element CSS property on the page
- * Thanks to JavaScript Kit: http://www.javascriptkit.com/dhtmltutors/dhtmlcascade4.shtml
- *
- * @api private
- * @method _getPropValue
- * @param {Object} element
- * @param {String} propName
- * @returns Element's property value
- */
-function _getPropValue (element, propName) {
-  var propValue = '';
-  if (element.currentStyle) { //IE
-    propValue = element.currentStyle[propName];
-  } else if (document.defaultView && document.defaultView.getComputedStyle) { //Others
-    propValue = document.defaultView.getComputedStyle(element, null).getPropertyValue(propName);
-  }
-
-  //Prevent exception in IE
-  if (propValue && propValue.toLowerCase) {
-    return propValue.toLowerCase();
-  } else {
-    return propValue;
-  }
-}
-
-/**
- * Checks to see if target element (or parents) position is fixed or not
- *
- * @api private
- * @method _isFixed
- * @param {Object} element
- * @returns Boolean
- */
-function _isFixed (element) {
-  var p = element.parentNode;
-
-  if (!p || p.nodeName === 'HTML') {
-    return false;
-  }
-
-  if (_getPropValue(element, 'position') === 'fixed') {
-    return true;
-  }
-
-  return _isFixed(p);
-}
-
-/**
- * Provides a cross-browser way to get the screen dimensions
- * via: http://stackoverflow.com/questions/5864467/internet-explorer-innerheight
- *
- * @api private
- * @method _getWinSize
- * @returns {Object} width and height attributes
- */
-function _getWinSize() {
-  if (window.innerWidth !== undefined) {
-    return { width: window.innerWidth, height: window.innerHeight };
-  } else {
-    var D = document.documentElement;
-    return { width: D.clientWidth, height: D.clientHeight };
-  }
-}
-
-/**
- * Check to see if the element is in the viewport or not
- * http://stackoverflow.com/questions/123999/how-to-tell-if-a-dom-element-is-visible-in-the-current-viewport
- *
- * @api private
- * @method _elementInViewport
- * @param {Object} el
- */
-function _elementInViewport(el) {
-  var rect = el.getBoundingClientRect();
-
-  return (
-    rect.top >= 0 &&
-    rect.left >= 0 &&
-    (rect.bottom+80) <= window.innerHeight && // add 80 to get the text right
-    rect.right <= window.innerWidth
-  );
-}
-
-/**
- * Add overlay layer to the page
- *
- * @api private
- * @method _addOverlayLayer
- * @param {Object} targetElm
- */
-function _addOverlayLayer(targetElm) {
-  var overlayLayer = document.createElement('div'),
-      styleText = '',
-      self = this;
-
-  //set css class name
-  overlayLayer.className = 'introjs-overlay';
-
-  //check if the target element is body, we should calculate the size of overlay layer in a better way
-  if (!targetElm.tagName || targetElm.tagName.toLowerCase() === 'body') {
-    styleText += 'top: 0;bottom: 0; left: 0;right: 0;position: fixed;';
-    overlayLayer.setAttribute('style', styleText);
-  } else {
-    //set overlay layer position
-    var elementPosition = _getOffset(targetElm);
-    if (elementPosition) {
-      styleText += 'width: ' + elementPosition.width + 'px; height:' + elementPosition.height + 'px; top:' + elementPosition.top + 'px;left: ' + elementPosition.left + 'px;';
-      overlayLayer.setAttribute('style', styleText);
-    }
-  }
-
-  targetElm.appendChild(overlayLayer);
-
-  overlayLayer.onclick = function() {
-    if (self._blockUserInteraction) return;
-    if (self._options.exitOnOverlayClick === true) {
-      _exitIntro.call(self, targetElm);
-    }
-  };
-
-  window.setTimeout(function() {
-    styleText += 'opacity: ' + self._options.overlayOpacity.toString() + ';';
-    overlayLayer.setAttribute('style', styleText);
-  }, 10);
-
-  return true;
-}
-
-/**
- * Removes open hint (tooltip hint)
- *
- * @api private
- * @method _removeHintTooltip
- */
-function _removeHintTooltip() {
-  var tooltip = document.querySelector('.introjs-hintReference');
-
-  if (tooltip) {
-    var step = tooltip.getAttribute('data-step');
-    tooltip.parentNode.removeChild(tooltip);
-    return step;
-  }
-}
-
-/**
- * Start parsing hint items
- *
- * @api private
- * @param {Object} targetElm
- * @method _startHint
- */
-function _populateHints(targetElm) {
-
-  this._introItems = [];
-
-  if (this._options.hints) {
-    _forEach(this._options.hints, function (hint) {
-      var currentItem = _cloneObject(hint);
-
-      if (typeof(currentItem.element) === 'string') {
-        //grab the element with given selector from the page
-        currentItem.element = document.querySelector(currentItem.element);
+  /**
+  * Iterates arrays
+  *
+  * @param {Array} arr
+  * @param {Function} forEachFnc
+  * @param {Function} completeFnc
+  * @return {Null}
+  */
+  function _forEach(arr, forEachFnc, completeFnc) {
+    // in case arr is an empty query selector node list
+    if (arr) {
+      for (var i = 0, len = arr.length; i < len; i++) {
+        forEachFnc(arr[i], i);
       }
-
-      currentItem.hintPosition = currentItem.hintPosition || this._options.hintPosition;
-      currentItem.hintAnimation = currentItem.hintAnimation || this._options.hintAnimation;
-
-      if (currentItem.element !== null) {
-        this._introItems.push(currentItem);
-      }
-    }.bind(this));
-  } else {
-    var hints = targetElm.querySelectorAll('*[data-hint]');
-
-    if (!hints || !hints.length) {
-      return false;
     }
 
-    //first add intro items with data-step
-    _forEach(hints, function (currentElement) {
-      // hint animation
-      var hintAnimation = currentElement.getAttribute('data-hintanimation');
-
-      if (hintAnimation) {
-        hintAnimation = (hintAnimation === 'true');
-      } else {
-        hintAnimation = this._options.hintAnimation;
-      }
-
-      this._introItems.push({
-        element: currentElement,
-        hint: currentElement.getAttribute('data-hint'),
-        hintPosition: currentElement.getAttribute('data-hintposition') || this._options.hintPosition,
-        hintAnimation: hintAnimation,
-        tooltipClass: currentElement.getAttribute('data-tooltipclass'),
-        position: currentElement.getAttribute('data-position') || this._options.tooltipPosition
-      });
-    }.bind(this));
-  }
-
-  _addHints.call(this);
-
-  if (document.addEventListener) {
-    document.addEventListener('click', _removeHintTooltip.bind(this), false);
-    //for window resize
-    window.addEventListener('resize', _reAlignHints.bind(this), true);
-  } else if (document.attachEvent) { //IE
-    //for window resize
-    document.attachEvent('onclick', _removeHintTooltip.bind(this));
-    document.attachEvent('onresize', _reAlignHints.bind(this));
-  }
-}
-
-/**
- * Re-aligns all hint elements
- *
- * @api private
- * @method _reAlignHints
- */
-function _reAlignHints() {
-  _forEach(this._introItems, function (item) {
-    if (typeof(item.targetElement) === 'undefined') {
-      return;
+    if (typeof(completeFnc) === 'function') {
+      completeFnc();
     }
-
-    _alignHintPosition.call(this, item.hintPosition, item.element, item.targetElement);
-  }.bind(this));
-}
-
-/**
-* Get a queryselector within the hint wrapper
-*
-* @param {String} selector
-* @return {NodeList|Array}
-*/
-function _hintQuerySelectorAll(selector) {
-  var hintsWrapper = document.querySelector('.introjs-hints');
-  return (hintsWrapper) ? hintsWrapper.querySelectorAll(selector) : [];
-}
-
-/**
- * Hide a hint
- *
- * @api private
- * @method _hideHint
- */
-function _hideHint(stepId) {
-  var hint = _hintQuerySelectorAll('.introjs-hint[data-step="' + stepId + '"]')[0];
-  
-  _removeHintTooltip.call(this);
-
-  if (hint) {
-    _addClass(hint, 'introjs-hidehint');
-  }
-
-  _executeEventListeners.call(this, EVENT_NAMES.hintClose, null, stepId);
-}
-
-/**
- * Hide all hints
- *
- * @api private
- * @method _hideHints
- */
-function _hideHints() {
-  var hints = _hintQuerySelectorAll('.introjs-hint');
-
-  _forEach(hints, function (hint) {
-    _hideHint.call(this, hint.getAttribute('data-step'));
-  }.bind(this));
-}
-
-/**
- * Show all hints
- *
- * @api private
- * @method _showHints
- */
-function _showHints() {
-  var hints = _hintQuerySelectorAll('.introjs-hint');
-
-  if (hints && hints.length) {
-    _forEach(hints, function (hint) {
-      _showHint.call(this, hint.getAttribute('data-step'));
-    }.bind(this));
-  } else {
-    _populateHints.call(this, this._targetElement);
-  }
-}
-
-/**
- * Show a hint
- *
- * @api private
- * @method _showHint
- */
-function _showHint(stepId) {
-  var hint = _hintQuerySelectorAll('.introjs-hint[data-step="' + stepId + '"]')[0];
-
-  if (hint) {
-    _removeClass(hint, /introjs-hidehint/g);
-  }
-}
-
-/**
- * Removes all hint elements on the page
- * Useful when you want to destroy the elements and add them again (e.g. a modal or popup)
- *
- * @api private
- * @method _removeHints
- */
-function _removeHints() {
-  var hints = _hintQuerySelectorAll('.introjs-hint');
-
-  _forEach(hints, function (hint) {
-    _removeHint.call(this, hint.getAttribute('data-step'));
-  }.bind(this));
-}
-
-/**
- * Remove one single hint element from the page
- * Useful when you want to destroy the element and add them again (e.g. a modal or popup)
- * Use removeHints if you want to remove all elements.
- *
- * @api private
- * @method _removeHint
- */
-function _removeHint(stepId) {
-  var hint = _hintQuerySelectorAll('.introjs-hint[data-step="' + stepId + '"]')[0];
-
-  if (hint) {
-    hint.parentNode.removeChild(hint);
-  }
-}
-
-/**
- * Add all available hints to the page
- *
- * @api private
- * @method _addHints
- */
-function _addHints() {
-  var self = this;
-
-  var hintsWrapper = document.querySelector('.introjs-hints');
-
-  if (hintsWrapper === null) {
-    hintsWrapper = document.createElement('div');
-    hintsWrapper.className = 'introjs-hints';
   }
 
   /**
-  * Returns an event handler unique to the hint iteration
-  * 
-  * @param {Integer} i
-  * @return {Function}
+   * Append a class to an element
+   *
+   * @api private
+   * @method _addClass
+   * @param {Object} element
+   * @param {String} className
+   * @returns null
+   */
+  function _addClass(element, className) {
+    if (element instanceof SVGElement) {
+      // svg
+      var pre = element.getAttribute('class') || '';
+
+      element.setAttribute('class', pre + ' ' + className);
+    } else {
+      if (element.classList !== undefined) {
+        // check for modern classList property
+        var classes = className.split(' ');
+        _forEach(classes, function (cls) {
+          element.classList.add( cls );
+        });
+      } else if (!element.className.match( className )) {
+        // check if element doesn't already have className
+        element.className += ' ' + className;
+      }
+    }
+  }
+
+  /**
+   * Remove a class from an element
+   *
+   * @api private
+   * @method _removeClass
+   * @param {Object} element
+   * @param {RegExp|String} classNameRegex can be regex or string
+   * @returns null
+   */
+  function _removeClass(element, classNameRegex) {
+    if (element instanceof SVGElement) {
+      var pre = element.getAttribute('class') || '';
+
+      element.setAttribute('class', pre.replace(classNameRegex, '').replace(/^\s+|\s+$/g, ''));
+    } else {
+      element.className = element.className.replace(classNameRegex, '').replace(/^\s+|\s+$/g, '');
+    }
+  }
+
+  /**
+   * Get an element CSS property on the page
+   * Thanks to JavaScript Kit: http://www.javascriptkit.com/dhtmltutors/dhtmlcascade4.shtml
+   *
+   * @api private
+   * @method _getPropValue
+   * @param {Object} element
+   * @param {String} propName
+   * @returns Element's property value
+   */
+  function _getPropValue (element, propName) {
+    var propValue = '';
+    if (element.currentStyle) { //IE
+      propValue = element.currentStyle[propName];
+    } else if (document.defaultView && document.defaultView.getComputedStyle) { //Others
+      propValue = document.defaultView.getComputedStyle(element, null).getPropertyValue(propName);
+    }
+
+    //Prevent exception in IE
+    if (propValue && propValue.toLowerCase) {
+      return propValue.toLowerCase();
+    } else {
+      return propValue;
+    }
+  }
+
+  /**
+   * Checks to see if target element (or parents) position is fixed or not
+   *
+   * @api private
+   * @method _isFixed
+   * @param {Object} element
+   * @returns Boolean
+   */
+  function _isFixed (element) {
+    var p = element.parentNode;
+
+    if (!p || p.nodeName === 'HTML') {
+      return false;
+    }
+
+    if (_getPropValue(element, 'position') === 'fixed') {
+      return true;
+    }
+
+    return _isFixed(p);
+  }
+
+  /**
+   * Provides a cross-browser way to get the screen dimensions
+   * via: http://stackoverflow.com/questions/5864467/internet-explorer-innerheight
+   *
+   * @api private
+   * @method _getWinSize
+   * @returns {Object} width and height attributes
+   */
+  function _getWinSize() {
+    if (window.innerWidth !== undefined) {
+      return { width: window.innerWidth, height: window.innerHeight };
+    } else {
+      var D = document.documentElement;
+      return { width: D.clientWidth, height: D.clientHeight };
+    }
+  }
+
+  /**
+   * Check to see if the element is in the viewport or not
+   * http://stackoverflow.com/questions/123999/how-to-tell-if-a-dom-element-is-visible-in-the-current-viewport
+   *
+   * @api private
+   * @method _elementInViewport
+   * @param {Object} el
+   */
+  function _elementInViewport(el) {
+    var rect = el.getBoundingClientRect();
+
+    return (
+      rect.top >= 0 &&
+      rect.left >= 0 &&
+      (rect.bottom+80) <= window.innerHeight && // add 80 to get the text right
+      rect.right <= window.innerWidth
+    );
+  }
+
+  /**
+   * Add overlay layer to the page
+   *
+   * @api private
+   * @method _addOverlayLayer
+   * @param {Object} targetElm
+   */
+  function _addOverlayLayer(targetElm) {
+    var overlayLayer = document.createElement('div'),
+        styleText = '',
+        self = this;
+
+    //set css class name
+    overlayLayer.className = 'introjs-overlay';
+
+    //check if the target element is body, we should calculate the size of overlay layer in a better way
+    if (!targetElm.tagName || targetElm.tagName.toLowerCase() === 'body') {
+      styleText += 'top: 0;bottom: 0; left: 0;right: 0;position: fixed;';
+      overlayLayer.setAttribute('style', styleText);
+    } else {
+      //set overlay layer position
+      var elementPosition = _getOffset(targetElm);
+      if (elementPosition) {
+        styleText += 'width: ' + elementPosition.width + 'px; height:' + elementPosition.height + 'px; top:' + elementPosition.top + 'px;left: ' + elementPosition.left + 'px;';
+        overlayLayer.setAttribute('style', styleText);
+      }
+    }
+
+    targetElm.appendChild(overlayLayer);
+
+    overlayLayer.onclick = function() {
+      if (self._blockUserInteraction) return;
+      if (self._options.exitOnOverlayClick === true) {
+        _exitIntro.call(self, targetElm);
+      }
+    };
+
+    window.setTimeout(function() {
+      styleText += 'opacity: ' + self._options.overlayOpacity.toString() + ';';
+      overlayLayer.setAttribute('style', styleText);
+    }, 10);
+
+    return true;
+  }
+
+  /**
+   * Removes open hint (tooltip hint)
+   *
+   * @api private
+   * @method _removeHintTooltip
+   */
+  function _removeHintTooltip() {
+    var tooltip = document.querySelector('.introjs-hintReference');
+
+    if (tooltip) {
+      var step = tooltip.getAttribute('data-step');
+      tooltip.parentNode.removeChild(tooltip);
+      return step;
+    }
+  }
+
+  /**
+   * Start parsing hint items
+   *
+   * @api private
+   * @param {Object} targetElm
+   * @method _startHint
+   */
+  function _populateHints(targetElm) {
+
+    this._introItems = [];
+
+    if (this._options.hints) {
+      _forEach(this._options.hints, function (hint) {
+        var currentItem = _cloneObject(hint);
+
+        if (typeof(currentItem.element) === 'string') {
+          //grab the element with given selector from the page
+          currentItem.element = document.querySelector(currentItem.element);
+        }
+
+        currentItem.hintPosition = currentItem.hintPosition || this._options.hintPosition;
+        currentItem.hintAnimation = currentItem.hintAnimation || this._options.hintAnimation;
+
+        if (currentItem.element !== null) {
+          this._introItems.push(currentItem);
+        }
+      }.bind(this));
+    } else {
+      var hints = targetElm.querySelectorAll('*[data-hint]');
+
+      if (!hints || !hints.length) {
+        return false;
+      }
+
+      //first add intro items with data-step
+      _forEach(hints, function (currentElement) {
+        // hint animation
+        var hintAnimation = currentElement.getAttribute('data-hintanimation');
+
+        if (hintAnimation) {
+          hintAnimation = (hintAnimation === 'true');
+        } else {
+          hintAnimation = this._options.hintAnimation;
+        }
+
+        this._introItems.push({
+          element: currentElement,
+          hint: currentElement.getAttribute('data-hint'),
+          hintPosition: currentElement.getAttribute('data-hintposition') || this._options.hintPosition,
+          hintAnimation: hintAnimation,
+          tooltipClass: currentElement.getAttribute('data-tooltipclass'),
+          position: currentElement.getAttribute('data-position') || this._options.tooltipPosition
+        });
+      }.bind(this));
+    }
+
+    _addHints.call(this);
+
+    if (document.addEventListener) {
+      document.addEventListener('click', _removeHintTooltip.bind(this), false);
+      //for window resize
+      window.addEventListener('resize', _reAlignHints.bind(this), true);
+    } else if (document.attachEvent) { //IE
+      //for window resize
+      document.attachEvent('onclick', _removeHintTooltip.bind(this));
+      document.attachEvent('onresize', _reAlignHints.bind(this));
+    }
+  }
+
+  /**
+   * Re-aligns all hint elements
+   *
+   * @api private
+   * @method _reAlignHints
+   */
+  function _reAlignHints() {
+    _forEach(this._introItems, function (item) {
+      if (typeof(item.targetElement) === 'undefined') {
+        return;
+      }
+
+      _alignHintPosition.call(this, item.hintPosition, item.element, item.targetElement);
+    }.bind(this));
+  }
+
+  /**
+  * Get a queryselector within the hint wrapper
+  *
+  * @param {String} selector
+  * @return {NodeList|Array}
   */
-  var getHintClick = function (i) {
-    return function(e) {
-      var evt = e ? e : window.event;
-      
-      if (evt.stopPropagation) {
-        evt.stopPropagation();
-      }
-
-      if (evt.cancelBubble !== null) {
-        evt.cancelBubble = true;
-      }
-
-      _showHintDialog.call(self, i);
-    };
-  };
-
-  _forEach(this._introItems, function(item, i) {
-    // avoid append a hint twice
-    if (document.querySelector('.introjs-hint[data-step="' + i + '"]')) {
-      return;
-    }
-
-    var hint = document.createElement('a');
-    _setAnchorAsButton(hint);
-
-    hint.onclick = getHintClick(i);
-
-    hint.className = 'introjs-hint';
-
-    if (!item.hintAnimation) {
-      _addClass(hint, 'introjs-hint-no-anim');
-    }
-
-    // hint's position should be fixed if the target element's position is fixed
-    if (_isFixed(item.element)) {
-      _addClass(hint, 'introjs-fixedhint');
-    }
-
-    var hintDot = document.createElement('div');
-    hintDot.className = 'introjs-hint-dot';
-    var hintPulse = document.createElement('div');
-    hintPulse.className = 'introjs-hint-pulse';
-
-    hint.appendChild(hintDot);
-    hint.appendChild(hintPulse);
-    hint.setAttribute('data-step', i);
-
-    // we swap the hint element with target element
-    // because _setHelperLayerPosition uses `element` property
-    item.targetElement = item.element;
-    item.element = hint;
-
-    // align the hint position
-    _alignHintPosition.call(this, item.hintPosition, hint, item.targetElement);
-
-    hintsWrapper.appendChild(hint);
-  }.bind(this));
-
-  // adding the hints wrapper
-  document.body.appendChild(hintsWrapper);
-
-  _executeEventListeners.call(this, EVENT_NAMES.hintsAdded, null);
-}
-
-/**
- * Aligns hint position
- *
- * @api private
- * @method _alignHintPosition
- * @param {String} position
- * @param {Object} hint
- * @param {Object} element
- */
-function _alignHintPosition(position, hint, element) {
-  // get/calculate offset of target element
-  var offset = _getOffset.call(this, element);
-  var iconWidth = 20;
-  var iconHeight = 20;
-
-  // align the hint element
-  switch (position) {
-    default:
-    case 'top-left':
-      hint.style.left = offset.left + 'px';
-      hint.style.top = offset.top + 'px';
-      break;
-    case 'top-right':
-      hint.style.left = (offset.left + offset.width - iconWidth) + 'px';
-      hint.style.top = offset.top + 'px';
-      break;
-    case 'bottom-left':
-      hint.style.left = offset.left + 'px';
-      hint.style.top = (offset.top + offset.height - iconHeight) + 'px';
-      break;
-    case 'bottom-right':
-      hint.style.left = (offset.left + offset.width - iconWidth) + 'px';
-      hint.style.top = (offset.top + offset.height - iconHeight) + 'px';
-      break;
-    case 'middle-left':
-      hint.style.left = offset.left + 'px';
-      hint.style.top = (offset.top + (offset.height - iconHeight) / 2) + 'px';
-      break;
-    case 'middle-right':
-      hint.style.left = (offset.left + offset.width - iconWidth) + 'px';
-      hint.style.top = (offset.top + (offset.height - iconHeight) / 2) + 'px';
-      break;
-    case 'middle-middle':
-      hint.style.left = (offset.left + (offset.width - iconWidth) / 2) + 'px';
-      hint.style.top = (offset.top + (offset.height - iconHeight) / 2) + 'px';
-      break;
-    case 'bottom-middle':
-      hint.style.left = (offset.left + (offset.width - iconWidth) / 2) + 'px';
-      hint.style.top = (offset.top + offset.height - iconHeight) + 'px';
-      break;
-    case 'top-middle':
-      hint.style.left = (offset.left + (offset.width - iconWidth) / 2) + 'px';
-      hint.style.top = offset.top + 'px';
-      break;
-  }
-}
-
-/**
- * Triggers when user clicks on the hint element
- *
- * @api private
- * @method _showHintDialog
- * @param {Number} stepId
- */
-function _showHintDialog(stepId) {
-  var hintElement = document.querySelector('.introjs-hint[data-step="' + stepId + '"]');
-  var item = this._introItems[stepId];
-
-  _executeEventListeners.call(this, EVENT_NAMES.hintClick, null, hintElement, item, stepId).then(function() {
-    // remove all open tooltips
-    var removedStep = _removeHintTooltip.call(this);
-
-    // to toggle the tooltip
-    if (parseInt(removedStep, 10) === stepId) {
-      return;
-    }
-
-    var tooltipLayer = document.createElement('div');
-    var tooltipTextLayer = document.createElement('div');
-    var arrowLayer = document.createElement('div');
-    var referenceLayer = document.createElement('div');
-
-    tooltipLayer.className = 'introjs-tooltip';
-
-    tooltipLayer.onclick = function (e) {
-      //IE9 & Other Browsers
-      if (e.stopPropagation) {
-        e.stopPropagation();
-      }
-      //IE8 and Lower
-      else {
-        e.cancelBubble = true;
-      }
-    };
-
-    tooltipTextLayer.className = 'introjs-tooltiptext';
-
-    var tooltipWrapper = document.createElement('p');
-    tooltipWrapper.innerHTML = item.hint;
-
-    var closeButton = document.createElement('a');
-    closeButton.className = 'introjs-button';
-    closeButton.setAttribute('role', 'button');
-    closeButton.innerHTML = this._options.hintButtonLabel;
-    closeButton.onclick = _hideHint.bind(this, stepId);
-
-    tooltipTextLayer.appendChild(tooltipWrapper);
-    tooltipTextLayer.appendChild(closeButton);
-
-    arrowLayer.className = 'introjs-arrow';
-    tooltipLayer.appendChild(arrowLayer);
-
-    tooltipLayer.appendChild(tooltipTextLayer);
-
-    // set current step for _placeTooltip function
-    this._currentStep = hintElement.getAttribute('data-step');
-
-    // align reference layer position
-    referenceLayer.className = 'introjs-tooltipReferenceLayer introjs-hintReference';
-    referenceLayer.setAttribute('data-step', hintElement.getAttribute('data-step'));
-    _setHelperLayerPosition.call(this, referenceLayer);
-
-    referenceLayer.appendChild(tooltipLayer);
-    document.body.appendChild(referenceLayer);
-
-    //set proper position
-    _placeTooltip.call(this, hintElement, tooltipLayer, arrowLayer, null, true);
-
-    // make sure that the tooltip is visible
-    _setLayerOpacity(1);
-  }.bind(this));
-}
-
-/**
- * Get an element position on the page
- * Thanks to `meouw`: http://stackoverflow.com/a/442474/375966
- *
- * @api private
- * @method _getOffset
- * @param {Object} element
- * @returns Element's position info
- */
-function _getOffset(element) {
-  var elementPosition = {};
-
-  var body = document.body;
-  var docEl = document.documentElement;
-
-  var scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop;
-  var scrollLeft = window.pageXOffset || docEl.scrollLeft || body.scrollLeft;
-
-  if (element instanceof SVGElement) {
-    var x = element.getBoundingClientRect();
-    elementPosition.top = x.top + scrollTop;
-    elementPosition.width = x.width;
-    elementPosition.height = x.height;
-    elementPosition.left = x.left + scrollLeft;
-  } else {
-    //set width
-    elementPosition.width = element.offsetWidth;
-
-    //set height
-    elementPosition.height = element.offsetHeight;
-
-    //calculate element top and left
-    var _x = 0;
-    var _y = 0;
-    while (element && !isNaN(element.offsetLeft) && !isNaN(element.offsetTop)) {
-      _x += element.offsetLeft;
-      _y += element.offsetTop;
-      element = element.offsetParent;
-    }
-    //set top
-    elementPosition.top = _y;
-    //set left
-    elementPosition.left = _x;
+  function _hintQuerySelectorAll(selector) {
+    var hintsWrapper = document.querySelector('.introjs-hints');
+    return (hintsWrapper) ? hintsWrapper.querySelectorAll(selector) : [];
   }
 
-  return elementPosition;
-}
-
-/**
- * Gets the current progress percentage
- *
- * @api private
- * @method _getProgress
- * @returns current progress percentage
- */
-function _getProgress() {
-  // Steps are 0 indexed
-  var currentStep = parseInt((this._currentStep + 1), 10);
-  return ((currentStep / this._introItems.length) * 100);
-}
-
-/**
- * Overwrites obj1's values with obj2's and adds obj2's if non existent in obj1
- * via: http://stackoverflow.com/questions/171251/how-can-i-merge-properties-of-two-javascript-objects-dynamically
- *
- * @api private
- * @param obj1
- * @param obj2
- * @returns obj3 a new object based on obj1 and obj2
- */
-function _mergeOptions(obj1,obj2) {
-  var obj3 = {},
-    attrname;
-  for (attrname in obj1) { obj3[attrname] = obj1[attrname]; }
-  for (attrname in obj2) { obj3[attrname] = obj2[attrname]; }
-  return obj3;
-}
-
-/**
-* Exits a running intro and optionally blocks all subsequent event handling. 
-*
-* @method _failIntro
-* @param {boolean|null} blockEvents Default is true
-* @returns {undefined} 
-*/
-function _failIntro(blockEvents) {
-  this._blockEventHandling = (typeof blockEvents === 'boolean') ? blockEvents : true;
-  _exitIntro.call(this, this._targetElement, true);
-}
-
-/**
- * Set the opacity of tooltip and reference layer to a given value.
- * Fades these layers in/out, when the intro flow is suspended by an event handler.  
- *
- * @api private
- * @method _setLayerOpacity
- * @param {Number} Opacity
- */
-function _setLayerOpacity(opacity) {
-  var helperLayer = document.querySelector('.introjs-helperLayer');
-  if (helperLayer) {
-    helperLayer.style.opacity = opacity;
-  }
-
-  var referenceLayer = document.querySelector('.introjs-tooltipReferenceLayer');
-  if (referenceLayer) {
-    referenceLayer.style.opacity = opacity;
-  }
-}
-
-// ModulePromise is either a reference to the global Promise prototype, or a simple 
-// surrogate that resolves immediately and does nothing in the reject case.
-// Any Promise polyfill should be provided from the outside.
-var ModulePromise;
-if (window && window.Promise) {
-  ModulePromise = window.Promise;
-} else {
-  ModulePromise = function (fn) {
-    this.resolvedValue = null;
-    fn(function(value) {
-      this.resolvedValue = value;
-    }.bind(this));
-  };
-
-  ModulePromise.prototype.then = function (resolveFn) {
-    resolveFn(this.resolvedValue);
-    return this;
-  };
-
-  ModulePromise.prototype.catch = function () {
-    return this;
-  };
-
-  ModulePromise.all = function (array) {
-    return new ModulePromise(function(resolve) {
-      resolve(array);
-    });
-  };
-}
-
-/**
- * Executes all event listeners for a given event name.
- * Returns a promise, which resolves when all promises that where returned from the 
- * event listeners are resolved. If one of the event listener's promises rejects, then
- * the promise rturned by this function will also reject.
- * The event listeners can also return non-promise types, which will always be resolved.
- *
- * @method _executeEventListeners
- * @param {String} eventName Canonical name of an event from EVENT_NAMES
- * @param {Boolean|null} defaultResolvedBoolean The default boolean value for the Promise resolution, or null
- * @returns {Promise|Object} Promise or simple object, that mimicks a Promise's then()
- */
-function _executeEventListeners(eventName, defaultResolvedBoolean) {
-  if (this._blockEventHandling === false) {
-    var promiseArray = [];
-    // get non-assigned parameters (Rest operator)
-    var args = [].slice.call(arguments, 2);
-    // call all event handlers and save their returned values in promiseArray
-    _forEach(this._eventHandler[eventName], function(callbackHandler) {
-      // detach callbacks that shall be called only once
-      if (callbackHandler.callOnce) {
-        this.detachEventHandler(
-          eventName,
-          callbackHandler.callbackFunction,
-          callbackHandler.callbackContext
-        );
-      }
-      // now call the event handler and save its return value
-      var returnValue = callbackHandler.callbackFunction.apply(
-        callbackHandler.callbackContext,
-        args
-      );
-      if (typeof returnValue !== 'undefined') { 
-        promiseArray.push(returnValue);
-      }
-    }.bind(this));
+  /**
+   * Hide a hint
+   *
+   * @api private
+   * @method _hideHint
+   */
+  function _hideHint(stepId) {
+    var hint = _hintQuerySelectorAll('.introjs-hint[data-step="' + stepId + '"]')[0];
     
-    if (typeof defaultResolvedBoolean === 'boolean') {
-      // if it's possible to reolve with a boolean, then return a promise
-      // that resolves after all returned booleans have been iterated
-      return new ModulePromise(function(resolve, reject) {
-        ModulePromise.all(promiseArray).then(function(values) {
-          var resolvedValue = defaultResolvedBoolean;
-          _forEach(values, function(value) {
-            if (typeof value === 'boolean' && value !== defaultResolvedBoolean) {
-              resolvedValue = value;
-            }
-          });
-          resolve(resolvedValue);
-        }, reject);
+    _removeHintTooltip.call(this);
+
+    if (hint) {
+      _addClass(hint, 'introjs-hidehint');
+    }
+
+    _executeEventListeners.call(this, EVENT_NAMES.hintClose, null, stepId);
+  }
+
+  /**
+   * Hide all hints
+   *
+   * @api private
+   * @method _hideHints
+   */
+  function _hideHints() {
+    var hints = _hintQuerySelectorAll('.introjs-hint');
+
+    _forEach(hints, function (hint) {
+      _hideHint.call(this, hint.getAttribute('data-step'));
+    }.bind(this));
+  }
+
+  /**
+   * Show all hints
+   *
+   * @api private
+   * @method _showHints
+   */
+  function _showHints() {
+    _executeEventListeners.call(this, EVENT_NAMES.hintsShow, null).then(function() {
+      var hints = _hintQuerySelectorAll('.introjs-hint');
+
+      if (hints && hints.length) {
+        _forEach(hints, function (hint) {
+          _showHint.call(this, hint.getAttribute('data-step'));
+        }.bind(this));
+      } else {
+        _populateHints.call(this, this._targetElement);
+      }
+    }.bind(this));
+  }
+
+  /**
+   * Show a hint
+   *
+   * @api private
+   * @method _showHint
+   */
+  function _showHint(stepId) {
+    var hint = _hintQuerySelectorAll('.introjs-hint[data-step="' + stepId + '"]')[0];
+
+    if (hint) {
+      _removeClass(hint, /introjs-hidehint/g);
+    }
+  }
+
+  /**
+   * Removes all hint elements on the page
+   * Useful when you want to destroy the elements and add them again (e.g. a modal or popup)
+   *
+   * @api private
+   * @method _removeHints
+   */
+  function _removeHints() {
+    var hints = _hintQuerySelectorAll('.introjs-hint');
+
+    _forEach(hints, function (hint) {
+      _removeHint.call(this, hint.getAttribute('data-step'));
+    }.bind(this));
+  }
+
+  /**
+   * Remove one single hint element from the page
+   * Useful when you want to destroy the element and add them again (e.g. a modal or popup)
+   * Use removeHints if you want to remove all elements.
+   *
+   * @api private
+   * @method _removeHint
+   */
+  function _removeHint(stepId) {
+    var hint = _hintQuerySelectorAll('.introjs-hint[data-step="' + stepId + '"]')[0];
+
+    if (hint) {
+      hint.parentNode.removeChild(hint);
+    }
+  }
+
+  /**
+   * Add all available hints to the page
+   *
+   * @api private
+   * @method _addHints
+   */
+  function _addHints() {
+    var self = this;
+
+    var hintsWrapper = document.querySelector('.introjs-hints');
+
+    if (hintsWrapper === null) {
+      hintsWrapper = document.createElement('div');
+      hintsWrapper.className = 'introjs-hints';
+    }
+
+    /**
+    * Returns an event handler unique to the hint iteration
+    * 
+    * @param {Integer} i
+    * @return {Function}
+    */
+    var getHintClick = function (i) {
+      return function(e) {
+        var evt = e ? e : window.event;
+        
+        if (evt.stopPropagation) {
+          evt.stopPropagation();
+        }
+
+        if (evt.cancelBubble !== null) {
+          evt.cancelBubble = true;
+        }
+
+        _showHintDialog.call(self, i);
+      };
+    };
+
+    _forEach(this._introItems, function(item, i) {
+      // avoid append a hint twice
+      if (document.querySelector('.introjs-hint[data-step="' + i + '"]')) {
+        return;
+      }
+
+      var hint = document.createElement('a');
+      _setAnchorAsButton(hint);
+
+      hint.onclick = getHintClick(i);
+
+      hint.className = 'introjs-hint';
+
+      if (!item.hintAnimation) {
+        _addClass(hint, 'introjs-hint-no-anim');
+      }
+
+      // hint's position should be fixed if the target element's position is fixed
+      if (_isFixed(item.element)) {
+        _addClass(hint, 'introjs-fixedhint');
+      }
+
+      var hintDot = document.createElement('div');
+      hintDot.className = 'introjs-hint-dot';
+      var hintPulse = document.createElement('div');
+      hintPulse.className = 'introjs-hint-pulse';
+
+      hint.appendChild(hintDot);
+      hint.appendChild(hintPulse);
+      hint.setAttribute('data-step', i);
+
+      // we swap the hint element with target element
+      // because _setHelperLayerPosition uses `element` property
+      item.targetElement = item.element;
+      item.element = hint;
+
+      // align the hint position
+      _alignHintPosition.call(this, item.hintPosition, hint, item.targetElement);
+
+      hintsWrapper.appendChild(hint);
+    }.bind(this));
+
+    // adding the hints wrapper
+    document.body.appendChild(hintsWrapper);
+
+    _executeEventListeners.call(this, EVENT_NAMES.hintsAdded, null);
+  }
+
+  /**
+   * Aligns hint position
+   *
+   * @api private
+   * @method _alignHintPosition
+   * @param {String} position
+   * @param {Object} hint
+   * @param {Object} element
+   */
+  function _alignHintPosition(position, hint, element) {
+    // get/calculate offset of target element
+    var offset = _getOffset.call(this, element);
+    var iconWidth = 20;
+    var iconHeight = 20;
+
+    // align the hint element
+    switch (position) {
+      default:
+      case 'top-left':
+        hint.style.left = offset.left + 'px';
+        hint.style.top = offset.top + 'px';
+        break;
+      case 'top-right':
+        hint.style.left = (offset.left + offset.width - iconWidth) + 'px';
+        hint.style.top = offset.top + 'px';
+        break;
+      case 'bottom-left':
+        hint.style.left = offset.left + 'px';
+        hint.style.top = (offset.top + offset.height - iconHeight) + 'px';
+        break;
+      case 'bottom-right':
+        hint.style.left = (offset.left + offset.width - iconWidth) + 'px';
+        hint.style.top = (offset.top + offset.height - iconHeight) + 'px';
+        break;
+      case 'middle-left':
+        hint.style.left = offset.left + 'px';
+        hint.style.top = (offset.top + (offset.height - iconHeight) / 2) + 'px';
+        break;
+      case 'middle-right':
+        hint.style.left = (offset.left + offset.width - iconWidth) + 'px';
+        hint.style.top = (offset.top + (offset.height - iconHeight) / 2) + 'px';
+        break;
+      case 'middle-middle':
+        hint.style.left = (offset.left + (offset.width - iconWidth) / 2) + 'px';
+        hint.style.top = (offset.top + (offset.height - iconHeight) / 2) + 'px';
+        break;
+      case 'bottom-middle':
+        hint.style.left = (offset.left + (offset.width - iconWidth) / 2) + 'px';
+        hint.style.top = (offset.top + offset.height - iconHeight) + 'px';
+        break;
+      case 'top-middle':
+        hint.style.left = (offset.left + (offset.width - iconWidth) / 2) + 'px';
+        hint.style.top = offset.top + 'px';
+        break;
+    }
+  }
+
+  /**
+   * Triggers when user clicks on the hint element
+   *
+   * @api private
+   * @method _showHintDialog
+   * @param {Number} stepId
+   */
+  function _showHintDialog(stepId) {
+    var hintElement = document.querySelector('.introjs-hint[data-step="' + stepId + '"]');
+    var item = this._introItems[stepId];
+
+    _executeEventListeners.call(this, EVENT_NAMES.hintClick, null, hintElement, item, stepId).then(function() {
+      // remove all open tooltips
+      var removedStep = _removeHintTooltip.call(this);
+
+      // to toggle the tooltip
+      if (parseInt(removedStep, 10) === stepId) {
+        return;
+      }
+
+      var tooltipLayer = document.createElement('div');
+      var tooltipTextLayer = document.createElement('div');
+      var arrowLayer = document.createElement('div');
+      var referenceLayer = document.createElement('div');
+
+      tooltipLayer.className = 'introjs-tooltip';
+
+      tooltipLayer.onclick = function (e) {
+        //IE9 & Other Browsers
+        if (e.stopPropagation) {
+          e.stopPropagation();
+        }
+        //IE8 and Lower
+        else {
+          e.cancelBubble = true;
+        }
+      };
+
+      tooltipTextLayer.className = 'introjs-tooltiptext';
+
+      var tooltipWrapper = document.createElement('p');
+      tooltipWrapper.innerHTML = item.hint;
+
+      var closeButton = document.createElement('a');
+      closeButton.className = 'introjs-button';
+      closeButton.setAttribute('role', 'button');
+      closeButton.innerHTML = this._options.hintButtonLabel;
+      closeButton.onclick = _hideHint.bind(this, stepId);
+
+      tooltipTextLayer.appendChild(tooltipWrapper);
+      tooltipTextLayer.appendChild(closeButton);
+
+      arrowLayer.className = 'introjs-arrow';
+      tooltipLayer.appendChild(arrowLayer);
+
+      tooltipLayer.appendChild(tooltipTextLayer);
+
+      // set current step for _placeTooltip function
+      this._currentStep = hintElement.getAttribute('data-step');
+
+      // align reference layer position
+      referenceLayer.className = 'introjs-tooltipReferenceLayer introjs-hintReference';
+      referenceLayer.setAttribute('data-step', hintElement.getAttribute('data-step'));
+      _setHelperLayerPosition.call(this, referenceLayer);
+
+      referenceLayer.appendChild(tooltipLayer);
+      document.body.appendChild(referenceLayer);
+
+      //set proper position
+      _placeTooltip.call(this, hintElement, tooltipLayer, arrowLayer, null, true);
+
+      // make sure that the tooltip is visible
+      _setLayerOpacity(1);
+    }.bind(this));
+  }
+
+  /**
+   * Get an element position on the page
+   * Thanks to `meouw`: http://stackoverflow.com/a/442474/375966
+   *
+   * @api private
+   * @method _getOffset
+   * @param {Object} element
+   * @returns Element's position info
+   */
+  function _getOffset(element) {
+    var elementPosition = {};
+
+    var body = document.body;
+    var docEl = document.documentElement;
+
+    var scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop;
+    var scrollLeft = window.pageXOffset || docEl.scrollLeft || body.scrollLeft;
+
+    if (element instanceof SVGElement) {
+      var x = element.getBoundingClientRect();
+      elementPosition.top = x.top + scrollTop;
+      elementPosition.width = x.width;
+      elementPosition.height = x.height;
+      elementPosition.left = x.left + scrollLeft;
+    } else {
+      //set width
+      elementPosition.width = element.offsetWidth;
+
+      //set height
+      elementPosition.height = element.offsetHeight;
+
+      //calculate element top and left
+      var _x = 0;
+      var _y = 0;
+      while (element && !isNaN(element.offsetLeft) && !isNaN(element.offsetTop)) {
+        _x += element.offsetLeft;
+        _y += element.offsetTop;
+        element = element.offsetParent;
+      }
+      //set top
+      elementPosition.top = _y;
+      //set left
+      elementPosition.left = _x;
+    }
+
+    return elementPosition;
+  }
+
+  /**
+   * Gets the current progress percentage
+   *
+   * @api private
+   * @method _getProgress
+   * @returns current progress percentage
+   */
+  function _getProgress() {
+    // Steps are 0 indexed
+    var currentStep = parseInt((this._currentStep + 1), 10);
+    return ((currentStep / this._introItems.length) * 100);
+  }
+
+  /**
+   * Overwrites obj1's values with obj2's and adds obj2's if non existent in obj1
+   * via: http://stackoverflow.com/questions/171251/how-can-i-merge-properties-of-two-javascript-objects-dynamically
+   *
+   * @api private
+   * @param obj1
+   * @param obj2
+   * @returns obj3 a new object based on obj1 and obj2
+   */
+  function _mergeOptions(obj1,obj2) {
+    var obj3 = {},
+      attrname;
+    for (attrname in obj1) { obj3[attrname] = obj1[attrname]; }
+    for (attrname in obj2) { obj3[attrname] = obj2[attrname]; }
+    return obj3;
+  }
+
+  /**
+  * Exits a running intro and optionally blocks all subsequent event handling. 
+  *
+  * @method _failIntro
+  * @param {boolean|null} blockEvents Default is true
+  * @returns {undefined} 
+  */
+  function _failIntro(blockEvents) {
+    this._blockEventHandling = (typeof blockEvents === 'boolean') ? blockEvents : true;
+    _exitIntro.call(this, this._targetElement, true);
+  }
+
+  /**
+   * Set the opacity of tooltip and reference layer to a given value.
+   * Fades these layers in/out, when the intro flow is suspended by an event handler.  
+   *
+   * @api private
+   * @method _setLayerOpacity
+   * @param {Number} Opacity
+   */
+  function _setLayerOpacity(opacity) {
+    var helperLayer = document.querySelector('.introjs-helperLayer');
+    if (helperLayer) {
+      helperLayer.style.opacity = opacity;
+    }
+
+    var referenceLayer = document.querySelector('.introjs-tooltipReferenceLayer');
+    if (referenceLayer) {
+      referenceLayer.style.opacity = opacity;
+    }
+  }
+
+  // ModulePromise is either a reference to the global Promise prototype, or a simple 
+  // surrogate that resolves immediately and does nothing in the reject case.
+  // Any Promise polyfill should be provided from the outside.
+  var ModulePromise;
+  if (window && window.Promise) {
+    ModulePromise = window.Promise;
+  } else {
+    ModulePromise = function (fn) {
+      this.resolvedValue = null;
+      fn(function(value) {
+        this.resolvedValue = value;
+      }.bind(this));
+    };
+
+    ModulePromise.prototype.then = function (resolveFn) {
+      resolveFn(this.resolvedValue);
+      return this;
+    };
+
+    ModulePromise.prototype.catch = function () {
+      return this;
+    };
+
+    ModulePromise.all = function (array) {
+      return new ModulePromise(function(resolve) {
+        resolve(array);
+      });
+    };
+  }
+
+  /**
+   * Executes all event listeners for a given event name.
+   * Returns a promise, which resolves when all promises that where returned from the 
+   * event listeners are resolved. If one of the event listener's promises rejects, then
+   * the promise rturned by this function will also reject.
+   * The event listeners can also return non-promise types, which will always be resolved.
+   *
+   * @method _executeEventListeners
+   * @param {String} eventName Canonical name of an event from EVENT_NAMES
+   * @param {Boolean|null} defaultResolvedBoolean The default boolean value for the Promise resolution, or null
+   * @returns {Promise|Object} Promise or simple object, that mimicks a Promise's then()
+   */
+  function _executeEventListeners(eventName, defaultResolvedBoolean) {
+    if (this._blockEventHandling === false) {
+      var promiseArray = [];
+      // get non-assigned parameters (Rest operator)
+      var args = [].slice.call(arguments, 2);
+      // call all event handlers and save their returned values in promiseArray
+      _forEach(this._eventHandler[eventName], function(callbackHandler) {
+        // detach callbacks that shall be called only once
+        if (callbackHandler.callOnce) {
+          this.detachEventHandler(
+            eventName,
+            callbackHandler.callbackFunction,
+            callbackHandler.callbackContext
+          );
+        }
+        // now call the event handler and save its return value
+        var returnValue = callbackHandler.callbackFunction.apply(
+          callbackHandler.callbackContext,
+          args
+        );
+        if (typeof returnValue !== 'undefined') { 
+          promiseArray.push(returnValue);
+        }
+      }.bind(this));
+      
+      if (typeof defaultResolvedBoolean === 'boolean') {
+        // if it's possible to reolve with a boolean, then return a promise
+        // that resolves after all returned booleans have been iterated
+        return new ModulePromise(function(resolve, reject) {
+          ModulePromise.all(promiseArray).then(function(values) {
+            var resolvedValue = defaultResolvedBoolean;
+            _forEach(values, function(value) {
+              if (typeof value === 'boolean' && value !== defaultResolvedBoolean) {
+                resolvedValue = value;
+              }
+            });
+            resolve(resolvedValue);
+          }, reject);
+        });
+      } else {
+        // as default, return a promise that waits until all callback promises resolve or one rejects
+        return ModulePromise.all(promiseArray);
+      }  
+    } else {
+      //in case of blocked event handling, return simple object
+      return {
+        then: function(resolve) {
+          resolve(defaultResolvedBoolean);
+        }
+      };
+    } 
+  }
+
+  var introJs = function (targetElm) {
+    if (typeof (targetElm) === 'object') {
+      //Ok, create a new instance
+      return new IntroJs(targetElm);
+
+    } else if (typeof (targetElm) === 'string') {
+      //select the target element with query selector
+      var targetElement = document.querySelector(targetElm);
+
+      if (targetElement) {
+        return new IntroJs(targetElement);
+      } else {
+        throw new Error('There is no element with given selector.');
+      }
+    } else {
+      return new IntroJs(document.body);
+    }
+  };
+
+  /**
+   * Current IntroJs version
+   *
+   * @property version
+   * @type String
+   */
+  introJs.version = VERSION;
+
+  //Prototype
+  introJs.fn = IntroJs.prototype = {
+    clone: function () {
+      return new IntroJs(this);
+    },
+    setOption: function(option, value) {
+      this._options[option] = value;
+      return this;
+    },
+    setOptions: function(options) {
+      this._options = _mergeOptions(this._options, options);
+      return this;
+    },
+    start: function () {
+      _introForElement.call(this, this._targetElement);
+      return this;
+    },
+    goToStep: function(step) {
+      _goToStep.call(this, step);
+      return this;
+    },
+    addStep: function(options) {
+      if (!this._options.steps) {
+        this._options.steps = [];
+      }
+
+      this._options.steps.push(options);
+
+      return this;
+    },
+    addSteps: function(steps) {
+      if (!steps.length) return;
+
+      for(var index = 0; index < steps.length; index++) {
+        this.addStep(steps[index]);
+      }
+
+      return this;
+    },
+    goToStepNumber: function(step) {
+      _goToStepNumber.call(this, step);
+
+      return this;
+    },
+    nextStep: function() {
+      _nextStep.call(this);
+      return this;
+    },
+    previousStep: function() {
+      _previousStep.call(this);
+      return this;
+    },
+    exit: function(force) {
+      _exitIntro.call(this, this._targetElement, force);
+      return this;
+    },
+    refresh: function() {
+      _refresh.call(this);
+      return this;
+    },
+    addHints: function() {
+      _populateHints.call(this, this._targetElement);
+      return this;
+    },
+    hideHint: function (stepId) {
+      _hideHint.call(this, stepId);
+      return this;
+    },
+    hideHints: function () {
+      _hideHints.call(this);
+      return this;
+    },
+    showHint: function (stepId) {
+      _showHint.call(this, stepId);
+      return this;
+    },
+    showHints: function () {
+      _showHints.call(this);
+      return this;
+    },
+    removeHints: function () {
+      _removeHints.call(this);
+      return this;
+    },
+    removeHint: function (stepId) {
+      _removeHint.call(this, stepId);
+      return this;
+    },
+    showHintDialog: function (stepId) {
+      _showHintDialog.call(this, stepId);
+      return this;
+    }
+  };
+
+  // create functions for event handler registration:
+  // onEvent
+  // attachEvent
+  // attachOnceEvent
+  // detachEvent
+  _forEach(Object.getOwnPropertyNames(EVENT_NAMES), function(key) {
+    var eventName = EVENT_NAMES[key];
+    IntroJs.prototype['attach' + eventName] = (function(closureEventName) {
+      return function(callbackFunction, callbackContext) {
+        return this.attachEventHandler(
+          closureEventName,
+          callbackFunction,
+          callbackContext,
+          false
+        );
+      };
+    })(eventName);
+
+    IntroJs.prototype['attachOnce' + eventName] = (function(closureEventName) {
+      return function(callbackFunction, callbackContext) {
+        return this.attachEventHandler(
+          closureEventName,
+          callbackFunction,
+          callbackContext,
+          true
+        );
+      };
+    })(eventName);
+
+    IntroJs.prototype['detach' + eventName] = (function(closureEventName) {
+      return function(callbackFunction, callbackContext) {
+        return this.detachEventHandler(
+          closureEventName,
+          callbackFunction,
+          callbackContext
+        );
+      };
+    })(eventName);
+
+    IntroJs.prototype['on' + eventName.toLowerCase()] = (function(closureEventName) {
+      return function(callbackFunction) {
+        return this.attachEventHandler(
+          closureEventName,
+          callbackFunction,
+          null,
+          false
+        );
+      };
+    })(eventName);
+  });
+
+  IntroJs.prototype.attachEventHandler = function(
+    eventName,
+    callbackFunction,
+    callbackContext,
+    callOnce
+  ) {
+    if (typeof callbackContext === 'undefined') {
+      callbackContext = null;
+    }
+
+    if (typeof callOnce === 'undefined') {
+      callOnce = false;
+    }
+
+    if (!this._eventHandler[eventName]) {
+      throw new Error('Event literal ' + eventName + ' is not valid.');
+    } else if (typeof callbackFunction === "function") {
+      this._eventHandler[eventName].push({
+        callbackFunction: callbackFunction,
+        callbackContext: callbackContext,
+        callOnce: callOnce
       });
     } else {
-      // as default, return a promise that waits until all callback promises resolve or one rejects
-      return ModulePromise.all(promiseArray);
-    }  
-  } else {
-    //in case of blocked event handling, return simple object
-    return {
-      then: function(resolve) {
-        resolve(defaultResolvedBoolean);
+      throw new Error('Provided callback for ' + eventName + ' is not a function.');
+    }
+    // return a function that lets the developer directly detach the event handler
+    return function () {
+      this.detachEventHandler(eventName, callbackFunction, callbackContext);
+    }.bind(this);
+  };
+
+  IntroJs.prototype.detachEventHandler = function(
+    eventName,
+    callbackFunction,
+    callbackContext
+  ) {
+    if (typeof callbackContext === 'undefined') {
+      callbackContext = null;
+    }
+
+    if (!this._eventHandler[eventName]) {
+      throw new Error('Event literal ' + eventName + ' is not valid.');
+    }
+    _forEach(this._eventHandler[eventName], function(callbackHandler, index) {
+      if (
+        callbackHandler.callbackFunction === callbackFunction &&
+        callbackHandler.callbackContext === callbackContext
+      ) {
+        this._eventHandler[eventName].splice(index, 1);
       }
-    };
-  } 
-}
-
-var introJs = function (targetElm) {
-  if (typeof (targetElm) === 'object') {
-    //Ok, create a new instance
-    return new IntroJs(targetElm);
-
-  } else if (typeof (targetElm) === 'string') {
-    //select the target element with query selector
-    var targetElement = document.querySelector(targetElm);
-
-    if (targetElement) {
-      return new IntroJs(targetElement);
-    } else {
-      throw new Error('There is no element with given selector.');
-    }
-  } else {
-    return new IntroJs(document.body);
-  }
-};
-
-/**
- * Current IntroJs version
- *
- * @property version
- * @type String
- */
-introJs.version = VERSION;
-
-//Prototype
-introJs.fn = IntroJs.prototype = {
-  clone: function () {
-    return new IntroJs(this);
-  },
-  setOption: function(option, value) {
-    this._options[option] = value;
+    }.bind(this));
     return this;
-  },
-  setOptions: function(options) {
-    this._options = _mergeOptions(this._options, options);
-    return this;
-  },
-  start: function () {
-    _introForElement.call(this, this._targetElement);
-    return this;
-  },
-  goToStep: function(step) {
-    _goToStep.call(this, step);
-    return this;
-  },
-  addStep: function(options) {
-    if (!this._options.steps) {
-      this._options.steps = [];
-    }
+  };
 
-    this._options.steps.push(options);
+  //expose event names, so that developers can use attach/detach directly.
+  introJs.EVENT_NAMES = EVENT_NAMES;
 
-    return this;
-  },
-  addSteps: function(steps) {
-    if (!steps.length) return;
+  introJs.fn = IntroJs.prototype;
 
-    for(var index = 0; index < steps.length; index++) {
-      this.addStep(steps[index]);
-    }
-
-    return this;
-  },
-  goToStepNumber: function(step) {
-    _goToStepNumber.call(this, step);
-
-    return this;
-  },
-  nextStep: function() {
-    _nextStep.call(this);
-    return this;
-  },
-  previousStep: function() {
-    _previousStep.call(this);
-    return this;
-  },
-  exit: function(force) {
-    _exitIntro.call(this, this._targetElement, force);
-    return this;
-  },
-  refresh: function() {
-    _refresh.call(this);
-    return this;
-  },
-  addHints: function() {
-    _populateHints.call(this, this._targetElement);
-    return this;
-  },
-  hideHint: function (stepId) {
-    _hideHint.call(this, stepId);
-    return this;
-  },
-  hideHints: function () {
-    _hideHints.call(this);
-    return this;
-  },
-  showHint: function (stepId) {
-    _showHint.call(this, stepId);
-    return this;
-  },
-  showHints: function () {
-    _showHints.call(this);
-    return this;
-  },
-  removeHints: function () {
-    _removeHints.call(this);
-    return this;
-  },
-  removeHint: function (stepId) {
-    _removeHint.call(this, stepId);
-    return this;
-  },
-  showHintDialog: function (stepId) {
-    _showHintDialog.call(this, stepId);
-    return this;
-  }
-};
-
-// create functions for event handler registration:
-// onEvent
-// attachEvent
-// attachOnceEvent
-// detachEvent
-_forEach(Object.getOwnPropertyNames(EVENT_NAMES), function(key) {
-  var eventName = EVENT_NAMES[key];
-  IntroJs.prototype['attach' + eventName] = (function(closureEventName) {
-    return function(callbackFunction, callbackContext) {
-      return this.attachEventHandler(
-        closureEventName,
-        callbackFunction,
-        callbackContext,
-        false
-      );
-    };
-  })(eventName);
-
-  IntroJs.prototype['attachOnce' + eventName] = (function(closureEventName) {
-    return function(callbackFunction, callbackContext) {
-      return this.attachEventHandler(
-        closureEventName,
-        callbackFunction,
-        callbackContext,
-        true
-      );
-    };
-  })(eventName);
-
-  IntroJs.prototype['detach' + eventName] = (function(closureEventName) {
-    return function(callbackFunction, callbackContext) {
-      return this.detachEventHandler(
-        closureEventName,
-        callbackFunction,
-        callbackContext
-      );
-    };
-  })(eventName);
-
-  IntroJs.prototype['on' + eventName.toLowerCase()] = (function(closureEventName) {
-    return function(callbackFunction) {
-      return this.attachEventHandler(
-        closureEventName,
-        callbackFunction,
-        null,
-        false
-      );
-    };
-  })(eventName);
-});
-
-IntroJs.prototype.attachEventHandler = function(
-  eventName,
-  callbackFunction,
-  callbackContext,
-  callOnce
-) {
-  if (typeof callbackContext === 'undefined') {
-    callbackContext = null;
-  }
-
-  if (typeof callOnce === 'undefined') {
-    callOnce = false;
-  }
-
-  if (!this._eventHandler[eventName]) {
-    throw new Error('Event literal ' + eventName + ' is not valid.');
-  } else if (typeof callbackFunction === "function") {
-    this._eventHandler[eventName].push({
-      callbackFunction: callbackFunction,
-      callbackContext: callbackContext,
-      callOnce: callOnce
-    });
-  } else {
-    throw new Error('Provided callback for ' + eventName + ' is not a function.');
-  }
-  // return a function that lets the developer directly detach the event handler
-  return function () {
-    this.detachEventHandler(eventName, callbackFunction, callbackContext);
-  }.bind(this);
-};
-
-IntroJs.prototype.detachEventHandler = function(
-  eventName,
-  callbackFunction,
-  callbackContext
-) {
-  if (typeof callbackContext === 'undefined') {
-    callbackContext = null;
-  }
-
-  if (!this._eventHandler[eventName]) {
-    throw new Error('Event literal ' + eventName + ' is not valid.');
-  }
-  _forEach(this._eventHandler[eventName], function(callbackHandler, index) {
-    if (
-      callbackHandler.callbackFunction === callbackFunction &&
-      callbackHandler.callbackContext === callbackContext
-    ) {
-      this._eventHandler[eventName].splice(index, 1);
-    }
-  }.bind(this));
-  return this;
-};
-
-//expose event names, so that developers can use attach/detach directly.
-introJs.EVENT_NAMES = EVENT_NAMES;
-
-introJs.fn = IntroJs.prototype;
-
-return introJs;
+  return introJs;
 });

--- a/intro.js
+++ b/intro.js
@@ -6,235 +6,265 @@
  */
 
 (function(f) {
-    if (typeof exports === "object" && typeof module !== "undefined") {
-        module.exports = f();
-        // deprecated function
-        // @since 2.8.0
-        module.exports.introJs = function () {
-          console.warn('Deprecated: please use require("intro.js") directly, instead of the introJs method of the function');
-          // introJs()
-          return f().apply(this, arguments);
-        };
-    } else if (typeof define === "function" && define.amd) {
-        define([], f);
-    } else {
-        var g;
-        if (typeof window !== "undefined") {
-            g = window;
-        } else if (typeof global !== "undefined") {
-            g = global;
-        } else if (typeof self !== "undefined") {
-            g = self;
-        } else {
-            g = this;
-        }
-        g.introJs = f();
-    }
+  if (typeof exports === "object" && typeof module !== "undefined") {
+      module.exports = f();
+      // deprecated function
+      // @since 2.8.0
+      module.exports.introJs = function () {
+        console.warn('Deprecated: please use require("intro.js") directly, instead of the introJs method of the function');
+        // introJs()
+        return f().apply(this, arguments);
+      };
+  } else if (typeof define === "function" && define.amd) {
+      define([], f);
+  } else {
+      var g;
+      if (typeof window !== "undefined") {
+          g = window;
+      } else if (typeof global !== "undefined") {
+          g = global;
+      } else if (typeof self !== "undefined") {
+          g = self;
+      } else {
+          g = this;
+      }
+      g.introJs = f();
+  }
 })(function () {
-  //Default config/variables
-  var VERSION = '2.9.0-alpha.1';
-  var POSITIONS = {
-    BOTTOM: 'bottom',
-    TOP: 'top',
-    RIGHT: 'right',
-    LEFT: 'left'
+//Default config/variables
+var VERSION = '2.9.0-alpha.1';
+
+//Create the list of event names as immutable object.
+//Let's us expose the event names as static property of the IntroJs class. 
+var EVENT_NAMES = Object.create({}, {
+  start: {
+    value: 'Start',
+    writable: false
+  },
+  beforeChange: {
+    value: 'BeforeChange',
+    writable: false
+  },
+  change: {
+    value: 'Change',
+    writable: false
+  },
+  afterChange: {
+    value: 'AfterChange',
+    writable: false
+  },
+  complete: {
+    value: 'Complete',
+    writable: false
+  },
+  hintsAdded: {
+    value: 'HintsAdded',
+    writable: false
+  },
+  hintClick: {
+    value: 'HintClick',
+    writable: false
+  },
+  hintClose: {
+    value: 'HintClose',
+    writable: false
+  },
+  exit: {
+    value: 'Exit',
+    writable: false
+  },
+  beforeExit: {
+    value: 'BeforeExit',
+    writable: false
+  }}
+);
+
+/**
+ * IntroJs main class
+ *
+ * @class IntroJs
+ */
+function IntroJs(obj) {
+  this._targetElement = obj;
+  this._introItems = [];
+
+  this._options = {
+    /* Next button label in tooltip box */
+    nextLabel: 'Next &rarr;',
+    /* Previous button label in tooltip box */
+    prevLabel: '&larr; Back',
+    /* Skip button label in tooltip box */
+    skipLabel: 'Skip',
+    /* Done button label in tooltip box */
+    doneLabel: 'Done',
+    /* Hide previous button in the first step? Otherwise, it will be disabled button. */
+    hidePrev: false,
+    /* Hide next button in the last step? Otherwise, it will be disabled button. */
+    hideNext: false,
+    /* Default tooltip box position */
+    tooltipPosition: 'bottom',
+    /* Next CSS class for tooltip boxes */
+    tooltipClass: '',
+    /* CSS class that is added to the helperLayer */
+    highlightClass: '',
+    /* Close introduction when pressing Escape button? */
+    exitOnEsc: true,
+    /* Close introduction when clicking on overlay layer? */
+    exitOnOverlayClick: true,
+    /* Show step numbers in introduction? */
+    showStepNumbers: true,
+    /* Let user use keyboard to navigate the tour? */
+    keyboardNavigation: true,
+    /* Show tour control buttons? */
+    showButtons: true,
+    /* Show tour bullets? */
+    showBullets: true,
+    /* Show tour progress? */
+    showProgress: false,
+    /* Scroll to highlighted element? */
+    scrollToElement: true,
+    /*
+     * Should we scroll the tooltip or target element?
+     *
+     * Options are: 'element' or 'tooltip'
+     */
+    scrollTo: 'element',
+    /* Padding to add after scrolling when element is not in the viewport (in pixels) */
+    scrollPadding: 30,
+    /* Set the overlay opacity */
+    overlayOpacity: 0.8,
+    /* Precedence of positions, when auto is enabled */
+    positionPrecedence: ["bottom", "top", "right", "left"],
+    /* Disable an interaction with element? */
+    disableInteraction: false,
+    /* Set how much padding to be used around helper element */
+    helperElementPadding: 10,
+    /* Default hint position */
+    hintPosition: 'top-middle',
+    /* Hint button label */
+    hintButtonLabel: 'Got it',
+    /* Adding animation to hints? */
+    hintAnimation: true
   };
 
-  //Create the list of event names as immutable object.
-  //Let's us expose the event names as static property of the IntroJs class. 
-  var EVENT_NAMES = Object.create({}, {
-    start: {
-      value: 'Start',
-      writable: false
-    },
-    beforeChange: {
-      value: 'BeforeChange',
-      writable: false
-    },
-    change: {
-      value: 'Change',
-      writable: false
-    },
-    afterChange: {
-      value: 'AfterChange',
-      writable: false
-    },
-    complete: {
-      value: 'Complete',
-      writable: false
-    },
-    hintsAdded: {
-      value: 'HintsAdded',
-      writable: false
-    },
-    hintClick: {
-      value: 'HintClick',
-      writable: false
-    },
-    hintClose: {
-      value: 'HintClose',
-      writable: false
-    },
-    exit: {
-      value: 'Exit',
-      writable: false
-    },
-    beforeExit: {
-      value: 'BeforeExit',
-      writable: false
-    }}
-  );
+  //create eventHandler object; one array for each event.
+  this._eventHandler = {};
+  _forEach(Object.getOwnPropertyNames(EVENT_NAMES), function(key) {
+    this._eventHandler[EVENT_NAMES[key]] = [];
+  }.bind(this));
 
-  /**
-   * IntroJs main class
-   *
-   * @class IntroJs
-   */
-  function IntroJs(obj) {
-    this._targetElement = obj;
-    this._introItems = [];
+  // in case of critical failures, this flag can block all event handling
+  this._blockEventHandling = false;
+  // this flag blocks keyboard and mouse/touch events during a step change
+  this._blockUserInteraction = false;
+}
 
-    this._options = {
-      /* Next button label in tooltip box */
-      nextLabel: 'Next &rarr;',
-      /* Previous button label in tooltip box */
-      prevLabel: '&larr; Back',
-      /* Skip button label in tooltip box */
-      skipLabel: 'Skip',
-      /* Done button label in tooltip box */
-      doneLabel: 'Done',
-      /* Hide previous button in the first step? Otherwise, it will be disabled button. */
-      hidePrev: false,
-      /* Hide next button in the last step? Otherwise, it will be disabled button. */
-      hideNext: false,
-      /* Default tooltip box position */
-      tooltipPosition: POSITIONS.BOTTOM,
-      /* Next CSS class for tooltip boxes */
-      tooltipClass: '',
-      /* CSS class that is added to the helperLayer */
-      highlightClass: '',
-      /* Close introduction when pressing Escape button? */
-      exitOnEsc: true,
-      /* Close introduction when clicking on overlay layer? */
-      exitOnOverlayClick: true,
-      /* Show step numbers in introduction? */
-      showStepNumbers: true,
-      /* Let user use keyboard to navigate the tour? */
-      keyboardNavigation: true,
-      /* Show tour control buttons? */
-      showButtons: true,
-      /* Show tour bullets? */
-      showBullets: true,
-      /* Show tour progress? */
-      showProgress: false,
-      /* Scroll to highlighted element? */
-      scrollToElement: true,
-      /*
-       * Should we scroll the tooltip or target element?
-       *
-       * Options are: 'element' or 'tooltip'
-       */
-      scrollTo: 'element',
-      /* Padding to add after scrolling when element is not in the viewport (in pixels) */
-      scrollPadding: 30,
-      /* Set the overlay opacity */
-      overlayOpacity: 0.75,
-      /* Precedence of positions, when auto is enabled */
-      positionPrecedence: [POSITIONS.BOTTOM, POSITIONS.TOP, POSITIONS.RIGHT, POSITIONS.LEFT],
-      /* Disable an interaction with element? */
-      disableInteraction: false,
-      /* Set how much padding to be used around helper element */
-      helperElementPadding: 10,
-      /* Default hint position */
-      hintPosition: 'top-middle',
-      /* Hint button label */
-      hintButtonLabel: 'Got it',
-      /* Adding animation to hints? */
-      hintAnimation: true
-    };
+/**
+ * Initiate a new introduction/guide from an element in the page
+ *
+ * @api private
+ * @method _introForElement
+ * @param {Object} targetElm
+ * @returns {Boolean} Success or not?
+ */
+function _introForElement(targetElm) {
+  var introItems = [],
+      self = this;
 
-    //create eventHandler object; one array for each event.
-    this._eventHandler = {};
-    _forEach(Object.getOwnPropertyNames(EVENT_NAMES), function(key) {
-      this._eventHandler[EVENT_NAMES[key]] = [];
-    }.bind(this));
+  if (this._options.steps) {
+    //use steps passed programmatically
+    _forEach(this._options.steps, function (step) {
+      var currentItem = _cloneObject(step);
 
-    // in case of critical failures, this flag can block all event handling
-    this._blockEventHandling = false;
-    // this flag blocks keyboard and mouse/touch events during a step change
-    this._blockUserInteraction = false;
-  }
+      //set the step
+      currentItem.step = introItems.length + 1;
 
-  /**
-   * Initiate a new introduction/guide from an element in the page
-   *
-   * @api private
-   * @method _introForElement
-   * @param {Object} targetElm
-   * @returns {Boolean} Success or not?
-   */
-  function _introForElement(targetElm) {
-    var introItems = [],
-        self = this;
-
-    if (this._options.steps) {
-      //use steps passed programmatically
-      _forEach(this._options.steps, function (step) {
-        var currentItem = _cloneObject(step);
-
-        //set the step
-        currentItem.step = introItems.length + 1;
-
-        //use querySelector function only when developer used CSS selector
-        if (typeof (currentItem.element) === 'string') {
-          //grab the element with given selector from the page
-          currentItem.element = document.querySelector(currentItem.element);
-        }
-
-        //intro without element
-        if (typeof (currentItem.element) === 'undefined' || currentItem.element === null) {
-          var floatingElementQuery = document.querySelector(".introjsFloatingElement");
-
-          if (floatingElementQuery === null) {
-            floatingElementQuery = document.createElement('div');
-            floatingElementQuery.className = 'introjsFloatingElement';
-
-            document.body.appendChild(floatingElementQuery);
-          }
-
-          currentItem.element  = floatingElementQuery;
-          currentItem.position = 'floating';
-        }
-
-        currentItem.scrollTo = currentItem.scrollTo || this._options.scrollTo;
-
-        if (typeof (currentItem.disableInteraction) === 'undefined') {
-          currentItem.disableInteraction = this._options.disableInteraction;
-        }
-
-        if (currentItem.element !== null) {
-          introItems.push(currentItem);
-        }        
-      }.bind(this));
-
-    } else {
-      //use steps from data-* annotations
-      var allIntroSteps = targetElm.querySelectorAll('*[data-intro]');
-      var elmsLength = allIntroSteps.length;
-      var disableInteraction;
-
-      //if there's no element to intro
-      if (elmsLength < 1) {
-        return false;
+      //use querySelector function only when developer used CSS selector
+      if (typeof (currentItem.element) === 'string') {
+        //grab the element with given selector from the page
+        currentItem.element = document.querySelector(currentItem.element);
       }
 
-      _forEach(allIntroSteps, function (currentElement) {
-        // skip hidden elements
-        if (currentElement.style.display === 'none') {
-          return;
+      //intro without element
+      if (typeof (currentItem.element) === 'undefined' || currentItem.element === null) {
+        var floatingElementQuery = document.querySelector(".introjsFloatingElement");
+
+        if (floatingElementQuery === null) {
+          floatingElementQuery = document.createElement('div');
+          floatingElementQuery.className = 'introjsFloatingElement';
+
+          document.body.appendChild(floatingElementQuery);
         }
 
-        var step = parseInt(currentElement.getAttribute('data-step'), 10);
+        currentItem.element  = floatingElementQuery;
+        currentItem.position = 'floating';
+      }
+
+      currentItem.scrollTo = currentItem.scrollTo || this._options.scrollTo;
+
+      if (typeof (currentItem.disableInteraction) === 'undefined') {
+        currentItem.disableInteraction = this._options.disableInteraction;
+      }
+
+      if (currentItem.element !== null) {
+        introItems.push(currentItem);
+      }        
+    }.bind(this));
+
+  } else {
+    //use steps from data-* annotations
+    var allIntroSteps = targetElm.querySelectorAll('*[data-intro]');
+    var elmsLength = allIntroSteps.length;
+    var disableInteraction;
+
+    //if there's no element to intro
+    if (elmsLength < 1) {
+      return false;
+    }
+
+    _forEach(allIntroSteps, function (currentElement) {
+      // skip hidden elements
+      if (currentElement.style.display === 'none') {
+        return;
+      }
+
+      var step = parseInt(currentElement.getAttribute('data-step'), 10);
+
+      if (typeof (currentElement.getAttribute('data-disable-interaction')) !== 'undefined') {
+        disableInteraction = !!currentElement.getAttribute('data-disable-interaction');
+      } else {
+        disableInteraction = this._options.disableInteraction;
+      }
+
+      if (step > 0) {
+        introItems[step - 1] = {
+          element: currentElement,
+          intro: currentElement.getAttribute('data-intro'),
+          step: parseInt(currentElement.getAttribute('data-step'), 10),
+          tooltipClass: currentElement.getAttribute('data-tooltipclass'),
+          highlightClass: currentElement.getAttribute('data-highlightclass'),
+          position: currentElement.getAttribute('data-position') || this._options.tooltipPosition,
+          scrollTo: currentElement.getAttribute('data-scrollto') || this._options.scrollTo,
+          disableInteraction: disableInteraction
+        };
+      }
+    }.bind(this));
+
+    //next add intro items without data-step
+    //todo: we need a cleanup here, two loops are redundant
+    var nextStep = 0;
+
+    _forEach(allIntroSteps, function (currentElement) {
+      if (currentElement.getAttribute('data-step') === null) {
+
+        while (true) {
+          if (typeof introItems[nextStep] === 'undefined') {
+            break;
+          } else {
+            nextStep++;
+          }
+        } 
+
 
         if (typeof (currentElement.getAttribute('data-disable-interaction')) !== 'undefined') {
           disableInteraction = !!currentElement.getAttribute('data-disable-interaction');
@@ -242,287 +272,214 @@
           disableInteraction = this._options.disableInteraction;
         }
 
-        if (step > 0) {
-          introItems[step - 1] = {
-            element: currentElement,
-            intro: currentElement.getAttribute('data-intro'),
-            step: parseInt(currentElement.getAttribute('data-step'), 10),
-            tooltipClass: currentElement.getAttribute('data-tooltipclass'),
-            highlightClass: currentElement.getAttribute('data-highlightclass'),
-            position: currentElement.getAttribute('data-position') || this._options.tooltipPosition,
-            scrollTo: currentElement.getAttribute('data-scrollto') || this._options.scrollTo,
-            disableInteraction: disableInteraction
-          };
-        }
-      }.bind(this));
+        introItems[nextStep] = {
+          element: currentElement,
+          intro: currentElement.getAttribute('data-intro'),
+          step: nextStep + 1,
+          tooltipClass: currentElement.getAttribute('data-tooltipclass'),
+          highlightClass: currentElement.getAttribute('data-highlightclass'),
+          position: currentElement.getAttribute('data-position') || this._options.tooltipPosition,
+          scrollTo: currentElement.getAttribute('data-scrollto') || this._options.scrollTo,
+          disableInteraction: disableInteraction
+        };
+      }
+    }.bind(this));
+  }
 
-      //next add intro items without data-step
-      //todo: we need a cleanup here, two loops are redundant
-      var nextStep = 0;
+  //removing undefined/null elements
+  var tempIntroItems = [];
+  for (var z = 0; z < introItems.length; z++) {
+    if (introItems[z]) {
+      // copy non-falsy values to the end of the array
+      tempIntroItems.push(introItems[z]);  
+    } 
+  }
 
-      _forEach(allIntroSteps, function (currentElement) {
-        if (currentElement.getAttribute('data-step') === null) {
+  introItems = tempIntroItems;
 
-          while (true) {
-            if (typeof introItems[nextStep] === 'undefined') {
-              break;
-            } else {
-              nextStep++;
-            }
-          } 
+  //Ok, sort all items with given steps
+  introItems.sort(function (a, b) {
+    return a.step - b.step;
+  });
 
+  //set it to the introJs object
+  self._introItems = introItems;
 
-          if (typeof (currentElement.getAttribute('data-disable-interaction')) !== 'undefined') {
-            disableInteraction = !!currentElement.getAttribute('data-disable-interaction');
-          } else {
-            disableInteraction = this._options.disableInteraction;
-          }
-
-          introItems[nextStep] = {
-            element: currentElement,
-            intro: currentElement.getAttribute('data-intro'),
-            step: nextStep + 1,
-            tooltipClass: currentElement.getAttribute('data-tooltipclass'),
-            highlightClass: currentElement.getAttribute('data-highlightclass'),
-            position: currentElement.getAttribute('data-position') || this._options.tooltipPosition,
-            scrollTo: currentElement.getAttribute('data-scrollto') || this._options.scrollTo,
-            disableInteraction: disableInteraction
-          };
-        }
-      }.bind(this));
-    }
-
-    //removing undefined/null elements
-    var tempIntroItems = [];
-    for (var z = 0; z < introItems.length; z++) {
-      if (introItems[z]) {
-        // copy non-falsy values to the end of the array
-        tempIntroItems.push(introItems[z]);  
-      } 
-    }
-
-    introItems = tempIntroItems;
-
-    //Ok, sort all items with given steps
-    introItems.sort(function (a, b) {
-      return a.step - b.step;
+  //add overlay layer to the page
+  if(_addOverlayLayer.call(self, targetElm)) {
+    _executeEventListeners.call(this, EVENT_NAMES.start, null).then(function () {
+      //then, start the show
+      _nextStep.call(self);
     });
 
-    //set it to the introJs object
-    self._introItems = introItems;
+    self._onKeyDown = function(e) {
+      /*
+      on keyCode:
+      https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
+      This feature has been removed from the Web standards.
+      Though some browsers may still support it, it is in
+      the process of being dropped.
+      Instead, you should use KeyboardEvent.code,
+      if it's implemented.
 
-    //add overlay layer to the page
-    if(_addOverlayLayer.call(self, targetElm)) {
-      _executeEventListeners.call(this, EVENT_NAMES.start, null).then(function () {
-        //then, start the show
+      jQuery's approach is to test for
+        (1) e.which, then
+        (2) e.charCode, then
+        (3) e.keyCode
+      https://github.com/jquery/jquery/blob/a6b0705294d336ae2f63f7276de0da1195495363/src/event.js#L638
+      */
+      if (self._blockUserInteraction) return;
+
+      var code = (e.code === null) ? e.which : e.code;
+
+      // if code/e.which is null
+      if (code === null) {
+        code = (e.charCode === null) ? e.keyCode : e.charCode;
+      }
+      
+      if ((code === 'Escape' || code === 27) && self._options.exitOnEsc === true) {
+        //escape key pressed, exit the intro
+        //check if exit callback is defined
+        _exitIntro.call(self, targetElm);
+      } else if (code === 'ArrowLeft' || code === 37) {
+        //left arrow
+        _previousStep.call(self);
+      } else if (code === 'ArrowRight' || code === 39) {
+        //right arrow
         _nextStep.call(self);
-      });
-
-      self._onKeyDown = function(e) {
-        /*
-        on keyCode:
-        https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
-        This feature has been removed from the Web standards.
-        Though some browsers may still support it, it is in
-        the process of being dropped.
-        Instead, you should use KeyboardEvent.code,
-        if it's implemented.
-
-        jQuery's approach is to test for
-          (1) e.which, then
-          (2) e.charCode, then
-          (3) e.keyCode
-        https://github.com/jquery/jquery/blob/a6b0705294d336ae2f63f7276de0da1195495363/src/event.js#L638
-        */
-        if (self._blockUserInteraction) return;
-
-        var code = (e.code === null) ? e.which : e.code;
-
-        // if code/e.which is null
-        if (code === null) {
-          code = (e.charCode === null) ? e.keyCode : e.charCode;
-        }
-        
-        if ((code === 'Escape' || code === 27) && self._options.exitOnEsc === true) {
-          //escape key pressed, exit the intro
-          //check if exit callback is defined
-          _exitIntro.call(self, targetElm);
-        } else if (code === 'ArrowLeft' || code === 37) {
-          //left arrow
+      } else if (code === 'Enter' || code === 13) {
+        //srcElement === ie
+        var target = e.target || e.srcElement;
+        if (target && target.className.match('introjs-prevbutton')) {
+          //user hit enter while focusing on previous button
           _previousStep.call(self);
-        } else if (code === 'ArrowRight' || code === 39) {
-          //right arrow
-          _nextStep.call(self);
-        } else if (code === 'Enter' || code === 13) {
-          //srcElement === ie
-          var target = e.target || e.srcElement;
-          if (target && target.className.match('introjs-prevbutton')) {
-            //user hit enter while focusing on previous button
-            _previousStep.call(self);
-          } else if (target && target.className.match('introjs-skipbutton')) {
-            //user hit enter while focusing on skip button
-            if (self._introItems.length - 1 === self._currentStep){
-                _executeEventListeners.call(self, EVENT_NAMES.complete, null).then(
-                  function() {
-                    _exitIntro.call(self, targetElm);
-                  },
-                  function(blockEvents) {
-                    _failIntro.call(self, blockEvents);
-                  });
-            } else {
-              _exitIntro.call(self, targetElm);
-            }
+        } else if (target && target.className.match('introjs-skipbutton')) {
+          //user hit enter while focusing on skip button
+          if (self._introItems.length - 1 === self._currentStep){
+              _executeEventListeners.call(self, EVENT_NAMES.complete, null).then(
+                function() {
+                  _exitIntro.call(self, targetElm);
+                },
+                function(blockEvents) {
+                  _failIntro.call(self, blockEvents);
+                });
           } else {
-            //default behavior for responding to enter  
-            _nextStep.call(self);
+            _exitIntro.call(self, targetElm);
           }
-
-          //prevent default behaviour on hitting Enter, to prevent steps being skipped in some browsers
-          if(e.preventDefault) {
-            e.preventDefault();
-          } else {
-            e.returnValue = false;
-          }
-        }
-      };
-
-      self._onResize = function() {
-        self.refresh.call(self);
-      };
-
-      if (window.addEventListener) {
-        if (this._options.keyboardNavigation) {
-          window.addEventListener('keydown', self._onKeyDown, true);
-        }
-        //for window resize
-        window.addEventListener('resize', self._onResize, true);
-      } else if (document.attachEvent) { //IE
-        if (this._options.keyboardNavigation) {
-          document.attachEvent('onkeydown', self._onKeyDown);
-        }
-        //for window resize
-        document.attachEvent('onresize', self._onResize);
-      }
-    }
-    return false;
-  }
-
- /*
-   * makes a copy of the object
-   * @api private
-   * @method _cloneObject
-  */
-  function _cloneObject(object) {
-      if (object === null || typeof (object) !== 'object' || typeof (object.nodeType) !== 'undefined') {
-        return object;
-      }
-      var temp = {};
-      for (var key in object) {
-        if (typeof(window.jQuery) !== 'undefined' && object[key] instanceof window.jQuery) {
-          temp[key] = object[key];
         } else {
-          temp[key] = _cloneObject(object[key]);
+          //default behavior for responding to enter  
+          _nextStep.call(self);
+        }
+
+        //prevent default behaviour on hitting Enter, to prevent steps being skipped in some browsers
+        if(e.preventDefault) {
+          e.preventDefault();
+        } else {
+          e.returnValue = false;
         }
       }
-      return temp;
-  }
-  /**
-   * Go to specific step of introduction
-   *
-   * @api private
-   * @method _goToStep
-   */
-  function _goToStep(step) {
-    //because steps starts with zero
-    this._currentStep = step - 2;
-    if (typeof (this._introItems) !== 'undefined') {
-      _nextStep.call(this);
+    };
+
+    self._onResize = function() {
+      self.refresh.call(self);
+    };
+
+    if (window.addEventListener) {
+      if (this._options.keyboardNavigation) {
+        window.addEventListener('keydown', self._onKeyDown, true);
+      }
+      //for window resize
+      window.addEventListener('resize', self._onResize, true);
+    } else if (document.attachEvent) { //IE
+      if (this._options.keyboardNavigation) {
+        document.attachEvent('onkeydown', self._onKeyDown);
+      }
+      //for window resize
+      document.attachEvent('onresize', self._onResize);
     }
   }
+  return false;
+}
 
-  /**
-   * Go to the specific step of introduction with the explicit [data-step] number
-   *
-   * @api private
-   * @method _goToStepNumber
-   */
-  function _goToStepNumber(step) {
-    this._currentStepNumber = step;
-    if (typeof (this._introItems) !== 'undefined') {
-      _nextStep.call(this);
+/*
+ * makes a copy of the object
+ * @api private
+ * @method _cloneObject
+*/
+function _cloneObject(object) {
+    if (object === null || typeof (object) !== 'object' || typeof (object.nodeType) !== 'undefined') {
+      return object;
     }
+    var temp = {};
+    for (var key in object) {
+      if (typeof(window.jQuery) !== 'undefined' && object[key] instanceof window.jQuery) {
+        temp[key] = object[key];
+      } else {
+        temp[key] = _cloneObject(object[key]);
+      }
+    }
+    return temp;
+}
+/**
+ * Go to specific step of introduction
+ *
+ * @api private
+ * @method _goToStep
+ */
+function _goToStep(step) {
+  //because steps starts with zero
+  this._currentStep = step - 2;
+  if (typeof (this._introItems) !== 'undefined') {
+    _nextStep.call(this);
+  }
+}
+
+/**
+ * Go to the specific step of introduction with the explicit [data-step] number
+ *
+ * @api private
+ * @method _goToStepNumber
+ */
+function _goToStepNumber(step) {
+  this._currentStepNumber = step;
+  if (typeof (this._introItems) !== 'undefined') {
+    _nextStep.call(this);
+  }
+}
+
+/**
+ * Go to next step on intro
+ *
+ * @api private
+ * @method _nextStep
+ */
+function _nextStep() {
+  this._blockUserInteraction = true;
+  this._direction = 'forward';
+
+  _setLayerOpacity(0);
+
+  if (typeof (this._currentStepNumber) !== 'undefined') {
+    _forEach(this._introItems, function (item, i) {
+      if( item.step === this._currentStepNumber ) {
+        this._currentStep = i - 1;
+        this._currentStepNumber = undefined;
+      }
+    }.bind(this));
   }
 
-  /**
-   * Go to next step on intro
-   *
-   * @api private
-   * @method _nextStep
-   */
-  function _nextStep() {
-    this._blockUserInteraction = true;
-    this._direction = 'forward';
-
-    _setLayerOpacity(0);
-
-    if (typeof (this._currentStepNumber) !== 'undefined') {
-      _forEach(this._introItems, function (item, i) {
-        if( item.step === this._currentStepNumber ) {
-          this._currentStep = i - 1;
-          this._currentStepNumber = undefined;
-        }
-      }.bind(this));
-    }
-
-    if (typeof (this._currentStep) === 'undefined') {
-      this._currentStep = 0;
-    } else {
-        ++this._currentStep;
-    }
-
-    if ((this._introItems.length) <= this._currentStep) {
-      // execute 'complete' handlers, then exit
-      _executeEventListeners.call(this, EVENT_NAMES.complete, null).then(function() {
-        _exitIntro.call(this, this._targetElement);
-      }.bind(this));
-    } else {
-
-      var nextStep = this._introItems[this._currentStep];
-
-      _executeEventListeners.call(this, EVENT_NAMES.beforeChange, true, nextStep.element).then(
-        function(continueStep) {
-          // if `onbeforechange` returned `false`, stop displaying the element
-          if (continueStep === false) {
-            --this._currentStep;
-            return false;
-          }
-          _showElement.call(this, nextStep);
-        }.bind(this)
-      ).catch(
-        function(blockEvents) {
-          _failIntro.call(this, blockEvents);
-        }.bind(this)
-      );
-    }
+  if (typeof (this._currentStep) === 'undefined') {
+    this._currentStep = 0;
+  } else {
+      ++this._currentStep;
   }
 
-  /**
-   * Go to previous step on intro
-   *
-   * @api private
-   * @method _previousStep
-   */
-  function _previousStep() {
-    this._direction = 'backward';
-
-    if (this._currentStep === 0) {
-      return false;
-    }
-
-    this._blockUserInteraction = true;
-    _setLayerOpacity(0);
-
-    --this._currentStep;
+  if ((this._introItems.length) <= this._currentStep) {
+    // execute 'complete' handlers, then exit
+    _executeEventListeners.call(this, EVENT_NAMES.complete, null).then(function() {
+      _exitIntro.call(this, this._targetElement);
+    }.bind(this));
+  } else {
 
     var nextStep = this._introItems[this._currentStep];
 
@@ -530,10 +487,9 @@
       function(continueStep) {
         // if `onbeforechange` returned `false`, stop displaying the element
         if (continueStep === false) {
-          ++this._currentStep;
+          --this._currentStep;
           return false;
         }
-
         _showElement.call(this, nextStep);
       }.bind(this)
     ).catch(
@@ -542,2088 +498,2102 @@
       }.bind(this)
     );
   }
+}
 
-  /**
-   * Update placement of the intro objects on the screen
-   * @api private
-   */
-  function _refresh() {
-    // re-align intros
-    _setHelperLayerPosition.call(this, document.querySelector('.introjs-helperLayer'));
-    _setHelperLayerPosition.call(this, document.querySelector('.introjs-tooltipReferenceLayer'));
-    _setHelperLayerPosition.call(this, document.querySelector('.introjs-disableInteraction'));
+/**
+ * Go to previous step on intro
+ *
+ * @api private
+ * @method _previousStep
+ */
+function _previousStep() {
+  this._direction = 'backward';
 
-    _setStepsOverlayPosition.call(this, this._introItems[this._currentStep]);
-
-    // re-align tooltip
-    if(this._currentStep !== undefined && this._currentStep !== null) {
-      var oldHelperNumberLayer = document.querySelector('.introjs-helperNumberLayer'),
-        oldArrowLayer        = document.querySelector('.introjs-arrow'),
-        oldtooltipContainer  = document.querySelector('.introjs-tooltip');
-      _placeTooltip.call(this, this._introItems[this._currentStep].element, oldtooltipContainer, oldArrowLayer, oldHelperNumberLayer);
-    }
-
-    //re-align hints
-    _reAlignHints.call(this);
-    return this;
+  if (this._currentStep === 0) {
+    return false;
   }
 
-  /**
-   * Exit from intro
-   *
-   * @api private
-   * @method _exitIntro
-   * @param {Object} targetElement
-   * @param {Boolean} force - Setting to `true` will skip the result of beforeExit callback
-   */
-  function _exitIntro(targetElement, force) {
-    _executeEventListeners.call(this, EVENT_NAMES.beforeExit, true).then(function(continueExit) {
-      // If event handler returns `false`, then skip the exit process.
-      // Skip this check if `force` parameter is `true`.
-      if (!force && continueExit === false) return;
-      
-      document.body.classList.remove('introjs-noscroll');
+  this._blockUserInteraction = true;
+  _setLayerOpacity(0);
 
-      //remove overlay layers from the page
-      var overlayLayers = targetElement.querySelectorAll('.introjs-overlay');
+  --this._currentStep;
 
-      if (overlayLayers && overlayLayers.length) {
-        _forEach(overlayLayers, function (overlayLayer) {
-          overlayLayer.style.opacity = 0;
-          window.setTimeout(function () {
-            if (this.parentNode) {
-              this.parentNode.removeChild(this);
-            }
-          }.bind(overlayLayer), 500);
-        }.bind(this));
+  var nextStep = this._introItems[this._currentStep];
+
+  _executeEventListeners.call(this, EVENT_NAMES.beforeChange, true, nextStep.element).then(
+    function(continueStep) {
+      // if `onbeforechange` returned `false`, stop displaying the element
+      if (continueStep === false) {
+        ++this._currentStep;
+        return false;
       }
 
-      //remove all helper layers
-      var helperLayer = targetElement.querySelector('.introjs-helperLayer');
-      if (helperLayer) {
-        helperLayer.parentNode.removeChild(helperLayer);
+      _showElement.call(this, nextStep);
+    }.bind(this)
+  ).catch(
+    function(blockEvents) {
+      _failIntro.call(this, blockEvents);
+    }.bind(this)
+  );
+}
+
+/**
+ * Update placement of the intro objects on the screen
+ * @api private
+ */
+function _refresh() {
+  // re-align intros
+  _setHelperLayerPosition.call(this, document.querySelector('.introjs-helperLayer'));
+  _setHelperLayerPosition.call(this, document.querySelector('.introjs-tooltipReferenceLayer'));
+  _setHelperLayerPosition.call(this, document.querySelector('.introjs-disableInteraction'));
+
+  // re-align tooltip
+  if(this._currentStep !== undefined && this._currentStep !== null) {
+    var oldHelperNumberLayer = document.querySelector('.introjs-helperNumberLayer'),
+      oldArrowLayer        = document.querySelector('.introjs-arrow'),
+      oldtooltipContainer  = document.querySelector('.introjs-tooltip');
+    _placeTooltip.call(this, this._introItems[this._currentStep].element, oldtooltipContainer, oldArrowLayer, oldHelperNumberLayer);
+  }
+
+  //re-align hints
+  _reAlignHints.call(this);
+  return this;
+}
+
+/**
+ * Exit from intro
+ *
+ * @api private
+ * @method _exitIntro
+ * @param {Object} targetElement
+ * @param {Boolean} force - Setting to `true` will skip the result of beforeExit callback
+ */
+function _exitIntro(targetElement, force) {
+  _executeEventListeners.call(this, EVENT_NAMES.beforeExit, true).then(function(continueExit) {
+    // If event handler returns `false`, then skip the exit process.
+    // Skip this check if `force` parameter is `true`.
+    if (!force && continueExit === false) return;
+
+    //remove overlay layers from the page
+    var overlayLayers = targetElement.querySelectorAll('.introjs-overlay');
+
+    if (overlayLayers && overlayLayers.length) {
+      _forEach(overlayLayers, function (overlayLayer) {
+        overlayLayer.style.opacity = 0;
+        window.setTimeout(function () {
+          if (this.parentNode) {
+            this.parentNode.removeChild(this);
+          }
+        }.bind(overlayLayer), 500);
+      }.bind(this));
+    }
+
+    //remove all helper layers
+    var helperLayer = targetElement.querySelector('.introjs-helperLayer');
+    if (helperLayer) {
+      helperLayer.parentNode.removeChild(helperLayer);
+    }
+
+    var referenceLayer = targetElement.querySelector('.introjs-tooltipReferenceLayer');
+    if (referenceLayer) {
+      referenceLayer.parentNode.removeChild(referenceLayer);
+    }
+
+    //remove disableInteractionLayer
+    var disableInteractionLayer = targetElement.querySelector('.introjs-disableInteraction');
+    if (disableInteractionLayer) {
+      disableInteractionLayer.parentNode.removeChild(disableInteractionLayer);
+    }
+
+    //remove intro floating element
+    var floatingElement = document.querySelector('.introjsFloatingElement');
+    if (floatingElement) {
+      floatingElement.parentNode.removeChild(floatingElement);
+    }
+
+    _removeShowElement();
+
+    //remove `introjs-fixParent` class from the elements
+    var fixParents = document.querySelectorAll('.introjs-fixParent');
+    _forEach(fixParents, function (parent) {
+      _removeClass(parent, /introjs-fixParent/g);
+    });
+
+    //clean listeners
+    if (window.removeEventListener) {
+      window.removeEventListener('keydown', this._onKeyDown, true);
+    } else if (document.detachEvent) { //IE
+      document.detachEvent('onkeydown', this._onKeyDown);
+    }
+
+    _executeEventListeners.call(this, EVENT_NAMES.exit, null).then(function() {
+      //set the step to zero
+      this._currentStep = undefined;
+      this._blockEventHandling = false;
+    }.bind(this));
+  }.bind(this));
+}
+
+/**
+ * Render tooltip box in the page
+ *
+ * @api private
+ * @method _placeTooltip
+ * @param {HTMLElement} targetElement
+ * @param {HTMLElement} tooltipLayer
+ * @param {HTMLElement} arrowLayer
+ * @param {HTMLElement} helperNumberLayer
+ * @param {Boolean} hintMode
+ */
+function _placeTooltip(targetElement, tooltipLayer, arrowLayer, helperNumberLayer, hintMode) {
+  var tooltipCssClass = '',
+      currentStepObj,
+      tooltipOffset,
+      targetOffset,
+      windowSize,
+      currentTooltipPosition;
+
+  hintMode = hintMode || false;
+
+  //reset the old style
+  tooltipLayer.style.top        = null;
+  tooltipLayer.style.right      = null;
+  tooltipLayer.style.bottom     = null;
+  tooltipLayer.style.left       = null;
+  tooltipLayer.style.marginLeft = null;
+  tooltipLayer.style.marginTop  = null;
+
+  arrowLayer.style.display = 'inherit';
+
+  if (typeof(helperNumberLayer) !== 'undefined' && helperNumberLayer !== null) {
+    helperNumberLayer.style.top  = null;
+    helperNumberLayer.style.left = null;
+  }
+
+  //prevent error when `this._currentStep` is undefined
+  if (!this._introItems[this._currentStep]) return;
+
+  //if we have a custom css class for each step
+  currentStepObj = this._introItems[this._currentStep];
+  if (typeof (currentStepObj.tooltipClass) === 'string') {
+    tooltipCssClass = currentStepObj.tooltipClass;
+  } else {
+    tooltipCssClass = this._options.tooltipClass;
+  }
+
+  tooltipLayer.className = ('introjs-tooltip ' + tooltipCssClass).replace(/^\s+|\s+$/g, '');
+  tooltipLayer.setAttribute('role', 'dialog');
+
+  currentTooltipPosition = this._introItems[this._currentStep].position;
+
+  // Floating is always valid, no point in calculating
+  if (currentTooltipPosition !== "floating") { 
+    currentTooltipPosition = _determineAutoPosition.call(this, targetElement, tooltipLayer, currentTooltipPosition);
+  }
+
+  var tooltipLayerStyleLeft;
+  targetOffset  = _getOffset(targetElement);
+  tooltipOffset = _getOffset(tooltipLayer);
+  windowSize    = _getWinSize();
+
+  _addClass(tooltipLayer, 'introjs-' + currentTooltipPosition);
+
+  switch (currentTooltipPosition) {
+    case 'top-right-aligned':
+      arrowLayer.className      = 'introjs-arrow bottom-right';
+
+      var tooltipLayerStyleRight = 0;
+      _checkLeft(targetOffset, tooltipLayerStyleRight, tooltipOffset, tooltipLayer);
+      tooltipLayer.style.bottom    = (targetOffset.height +  20) + 'px';
+      break;
+
+    case 'top-middle-aligned':
+      arrowLayer.className      = 'introjs-arrow bottom-middle';
+
+      var tooltipLayerStyleLeftRight = targetOffset.width / 2 - tooltipOffset.width / 2;
+
+      // a fix for middle aligned hints
+      if (hintMode) {
+        tooltipLayerStyleLeftRight += 5;
       }
 
-      var referenceLayer = targetElement.querySelector('.introjs-tooltipReferenceLayer');
-      if (referenceLayer) {
-        referenceLayer.parentNode.removeChild(referenceLayer);
+      if (_checkLeft(targetOffset, tooltipLayerStyleLeftRight, tooltipOffset, tooltipLayer)) {
+        tooltipLayer.style.right = null;
+        _checkRight(targetOffset, tooltipLayerStyleLeftRight, tooltipOffset, windowSize, tooltipLayer);
+      }
+      tooltipLayer.style.bottom = (targetOffset.height + 20) + 'px';
+      break;
+
+    case 'top-left-aligned':
+    // top-left-aligned is the same as the default top
+    case 'top':
+      arrowLayer.className = 'introjs-arrow bottom';
+
+      tooltipLayerStyleLeft = (hintMode) ? 0 : 15;
+
+      _checkRight(targetOffset, tooltipLayerStyleLeft, tooltipOffset, windowSize, tooltipLayer);
+      tooltipLayer.style.bottom = (targetOffset.height +  20) + 'px';
+      break;
+    case 'right':
+      tooltipLayer.style.left = (targetOffset.width + 20) + 'px';
+      if (targetOffset.top + tooltipOffset.height > windowSize.height) {
+        // In this case, right would have fallen below the bottom of the screen.
+        // Modify so that the bottom of the tooltip connects with the target
+        arrowLayer.className = "introjs-arrow left-bottom";
+        tooltipLayer.style.top = "-" + (tooltipOffset.height - targetOffset.height - 20) + "px";
+      } else {
+        arrowLayer.className = 'introjs-arrow left';
+      }
+      break;
+    case 'left':
+      if (!hintMode && this._options.showStepNumbers === true) {
+        tooltipLayer.style.top = '15px';
       }
 
-      //remove disableInteractionLayer
-      var disableInteractionLayer = targetElement.querySelector('.introjs-disableInteraction');
+      if (targetOffset.top + tooltipOffset.height > windowSize.height) {
+        // In this case, left would have fallen below the bottom of the screen.
+        // Modify so that the bottom of the tooltip connects with the target
+        tooltipLayer.style.top = "-" + (tooltipOffset.height - targetOffset.height - 20) + "px";
+        arrowLayer.className = 'introjs-arrow right-bottom';
+      } else {
+        arrowLayer.className = 'introjs-arrow right';
+      }
+      tooltipLayer.style.right = (targetOffset.width + 20) + 'px';
+
+      break;
+    case 'floating':
+      arrowLayer.style.display = 'none';
+
+      //we have to adjust the top and left of layer manually for intro items without element
+      tooltipLayer.style.left   = '50%';
+      tooltipLayer.style.top    = '50%';
+      tooltipLayer.style.marginLeft = '-' + (tooltipOffset.width / 2)  + 'px';
+      tooltipLayer.style.marginTop  = '-' + (tooltipOffset.height / 2) + 'px';
+
+      if (typeof(helperNumberLayer) !== 'undefined' && helperNumberLayer !== null) {
+        helperNumberLayer.style.left = '-' + ((tooltipOffset.width / 2) + 18) + 'px';
+        helperNumberLayer.style.top  = '-' + ((tooltipOffset.height / 2) + 18) + 'px';
+      }
+
+      break;
+    case 'bottom-right-aligned':
+      arrowLayer.className      = 'introjs-arrow top-right';
+
+      tooltipLayerStyleRight = 0;
+      _checkLeft(targetOffset, tooltipLayerStyleRight, tooltipOffset, tooltipLayer);
+      tooltipLayer.style.top    = (targetOffset.height +  20) + 'px';
+      break;
+
+    case 'bottom-middle-aligned':
+      arrowLayer.className      = 'introjs-arrow top-middle';
+
+      tooltipLayerStyleLeftRight = targetOffset.width / 2 - tooltipOffset.width / 2;
+
+      // a fix for middle aligned hints
+      if (hintMode) {
+        tooltipLayerStyleLeftRight += 5;
+      }
+
+      if (_checkLeft(targetOffset, tooltipLayerStyleLeftRight, tooltipOffset, tooltipLayer)) {
+        tooltipLayer.style.right = null;
+        _checkRight(targetOffset, tooltipLayerStyleLeftRight, tooltipOffset, windowSize, tooltipLayer);
+      }
+      tooltipLayer.style.top = (targetOffset.height + 20) + 'px';
+      break;
+
+    // case 'bottom-left-aligned':
+    // Bottom-left-aligned is the same as the default bottom
+    // case 'bottom':
+    // Bottom going to follow the default behavior
+    default:
+      arrowLayer.className = 'introjs-arrow top';
+
+      tooltipLayerStyleLeft = 0;
+      _checkRight(targetOffset, tooltipLayerStyleLeft, tooltipOffset, windowSize, tooltipLayer);
+      tooltipLayer.style.top    = (targetOffset.height +  20) + 'px';
+  }
+}
+
+/**
+ * Set tooltip left so it doesn't go off the right side of the window
+ *
+ * @return boolean true, if tooltipLayerStyleLeft is ok.  false, otherwise.
+ */
+function _checkRight(targetOffset, tooltipLayerStyleLeft, tooltipOffset, windowSize, tooltipLayer) {
+  if (targetOffset.left + tooltipLayerStyleLeft + tooltipOffset.width > windowSize.width) {
+    // off the right side of the window
+    tooltipLayer.style.left = (windowSize.width - tooltipOffset.width - targetOffset.left) + 'px';
+    return false;
+  }
+  tooltipLayer.style.left = tooltipLayerStyleLeft + 'px';
+  return true;
+}
+
+/**
+ * Set tooltip right so it doesn't go off the left side of the window
+ *
+ * @return boolean true, if tooltipLayerStyleRight is ok.  false, otherwise.
+ */
+function _checkLeft(targetOffset, tooltipLayerStyleRight, tooltipOffset, tooltipLayer) {
+  if (targetOffset.left + targetOffset.width - tooltipLayerStyleRight - tooltipOffset.width < 0) {
+    // off the left side of the window
+    tooltipLayer.style.left = (-targetOffset.left) + 'px';
+    return false;
+  }
+  tooltipLayer.style.right = tooltipLayerStyleRight + 'px';
+  return true;
+}
+
+/**
+ * Determines the position of the tooltip based on the position precedence and availability
+ * of screen space.
+ *
+ * @param {Object}    targetElement
+ * @param {Object}    tooltipLayer
+ * @param {String}    desiredTooltipPosition
+ * @return {String}   calculatedPosition
+ */
+function _determineAutoPosition(targetElement, tooltipLayer, desiredTooltipPosition) {
+
+  // Take a clone of position precedence. These will be the available
+  var possiblePositions = this._options.positionPrecedence.slice();
+
+  var windowSize = _getWinSize();
+  var tooltipHeight = _getOffset(tooltipLayer).height + 10;
+  var tooltipWidth = _getOffset(tooltipLayer).width + 20;
+  var targetElementRect = targetElement.getBoundingClientRect();
+
+  // If we check all the possible areas, and there are no valid places for the tooltip, the element
+  // must take up most of the screen real estate. Show the tooltip floating in the middle of the screen.
+  var calculatedPosition = "floating";
+
+  /*
+  * auto determine position 
+  */
+
+  // Check for space below
+  if (targetElementRect.bottom + tooltipHeight + tooltipHeight > windowSize.height) {
+    _removeEntry(possiblePositions, "bottom");
+  }
+
+  // Check for space above
+  if (targetElementRect.top - tooltipHeight < 0) {
+    _removeEntry(possiblePositions, "top");
+  }
+
+  // Check for space to the right
+  if (targetElementRect.right + tooltipWidth > windowSize.width) {
+    _removeEntry(possiblePositions, "right");
+  }
+
+  // Check for space to the left
+  if (targetElementRect.left - tooltipWidth < 0) {
+    _removeEntry(possiblePositions, "left");
+  }
+
+  // @var {String}  ex: 'right-aligned'
+  var desiredAlignment = (function (pos) {
+    var hyphenIndex = pos.indexOf('-');
+    if (hyphenIndex !== -1) {
+      // has alignment
+      return pos.substr(hyphenIndex);
+    }
+    return '';
+  })(desiredTooltipPosition || '');
+
+  // strip alignment from position
+  if (desiredTooltipPosition) {
+    // ex: "bottom-right-aligned"
+    // should return 'bottom'
+    desiredTooltipPosition = desiredTooltipPosition.split('-')[0];
+  }
+
+  if (possiblePositions.length) {
+    if (desiredTooltipPosition !== "auto" &&
+        possiblePositions.indexOf(desiredTooltipPosition) > -1) {
+      // If the requested position is in the list, choose that
+      calculatedPosition = desiredTooltipPosition;
+    } else {
+      // Pick the first valid position, in order
+      calculatedPosition = possiblePositions[0];
+    }
+  }
+
+  // only top and bottom positions have optional alignments
+  if (['top', 'bottom'].indexOf(calculatedPosition) !== -1) {
+    calculatedPosition += _determineAutoAlignment(targetElementRect.left, tooltipWidth, windowSize, desiredAlignment);
+  }
+
+  return calculatedPosition;
+}
+
+/**
+* auto-determine alignment
+* @param {Integer}  offsetLeft
+* @param {Integer}  tooltipWidth
+* @param {Object}   windowSize
+* @param {String}   desiredAlignment
+* @return {String}  calculatedAlignment
+*/
+function _determineAutoAlignment (offsetLeft, tooltipWidth, windowSize, desiredAlignment) {
+  var halfTooltipWidth = tooltipWidth / 2,
+    winWidth = Math.min(windowSize.width, window.screen.width),
+    possibleAlignments = ['-left-aligned', '-middle-aligned', '-right-aligned'],
+    calculatedAlignment = '';
+  
+  // valid left must be at least a tooltipWidth
+  // away from right side
+  if (winWidth - offsetLeft < tooltipWidth) {
+    _removeEntry(possibleAlignments, '-left-aligned');
+  }
+
+  // valid middle must be at least half 
+  // width away from both sides
+  if (offsetLeft < halfTooltipWidth || 
+    winWidth - offsetLeft < halfTooltipWidth) {
+    _removeEntry(possibleAlignments, '-middle-aligned');
+  }
+
+  // valid right must be at least a tooltipWidth
+  // width away from left side
+  if (offsetLeft < tooltipWidth) {
+    _removeEntry(possibleAlignments, '-right-aligned');
+  }
+
+  if (possibleAlignments.length) {
+    if (possibleAlignments.indexOf(desiredAlignment) !== -1) {
+      // the desired alignment is valid
+      calculatedAlignment = desiredAlignment;
+    } else {
+      // pick the first valid position, in order
+      calculatedAlignment = possibleAlignments[0];
+    }
+  } else {
+    // if screen width is too small 
+    // for ANY alignment, middle is 
+    // probably the best for visibility
+    calculatedAlignment = '-middle-aligned';
+  }
+
+  return calculatedAlignment;
+}
+
+/**
+ * Remove an entry from a string array if it's there, does nothing if it isn't there.
+ *
+ * @param {Array} stringArray
+ * @param {String} stringToRemove
+ */
+function _removeEntry(stringArray, stringToRemove) {
+  if (stringArray.indexOf(stringToRemove) > -1) {
+    stringArray.splice(stringArray.indexOf(stringToRemove), 1);
+  }
+}
+
+/**
+ * Update the position of the helper layer on the screen
+ *
+ * @api private
+ * @method _setHelperLayerPosition
+ * @param {Object} helperLayer
+ */
+function _setHelperLayerPosition(helperLayer) {
+  if (helperLayer) {
+    //prevent error when `this._currentStep` in undefined
+    if (!this._introItems[this._currentStep]) return;
+
+    var currentElement  = this._introItems[this._currentStep],
+        elementPosition = _getOffset(currentElement.element),
+        widthHeightPadding = this._options.helperElementPadding;
+
+    // If the target element is fixed, the tooltip should be fixed as well.
+    // Otherwise, remove a fixed class that may be left over from the previous
+    // step.
+    if (_isFixed(currentElement.element)) {
+      _addClass(helperLayer, 'introjs-fixedTooltip');
+    } else {
+      _removeClass(helperLayer, 'introjs-fixedTooltip');
+    }
+
+    if (currentElement.position === 'floating') {
+      widthHeightPadding = 0;
+    }
+
+    //set new position to helper layer
+    helperLayer.setAttribute('style', 'width: ' + (elementPosition.width  + widthHeightPadding)  + 'px; ' +
+                                      'height:' + (elementPosition.height + widthHeightPadding)  + 'px; ' +
+                                      'top:'    + (elementPosition.top    - widthHeightPadding / 2)   + 'px;' +
+                                      'left: '  + (elementPosition.left   - widthHeightPadding / 2)   + 'px;');
+
+  }
+}
+
+/**
+ * Add disableinteraction layer and adjust the size and position of the layer
+ *
+ * @api private
+ * @method _disableInteraction
+ */
+function _disableInteraction() {
+  var disableInteractionLayer = document.querySelector('.introjs-disableInteraction');
+
+  if (disableInteractionLayer === null) {
+    disableInteractionLayer = document.createElement('div');
+    disableInteractionLayer.className = 'introjs-disableInteraction';
+    this._targetElement.appendChild(disableInteractionLayer);
+  }
+
+  _setHelperLayerPosition.call(this, disableInteractionLayer);
+}
+
+/**
+ * Setting anchors to behave like buttons
+ *
+ * @api private
+ * @method _setAnchorAsButton
+ */
+function _setAnchorAsButton(anchor){
+  anchor.setAttribute('role', 'button');
+  anchor.tabIndex = 0;
+}
+
+/**
+ * Show an element on the page
+ *
+ * @api private
+ * @method _showElement
+ * @param {Object} targetElement
+ */
+function _showElement(targetElement) {
+  _executeEventListeners.call(this, EVENT_NAMES.change, null, targetElement.element).then(
+    function() {
+      var self = this,
+          oldHelperLayer = document.querySelector('.introjs-helperLayer'),
+          oldReferenceLayer = document.querySelector('.introjs-tooltipReferenceLayer'),
+          highlightClass = 'introjs-helperLayer',
+          nextTooltipButton,
+          prevTooltipButton,
+          skipTooltipButton;
+
+      //check for a current step highlight class
+      if (typeof (targetElement.highlightClass) === 'string') {
+        highlightClass += (' ' + targetElement.highlightClass);
+      }
+      //check for options highlight class
+      if (typeof (this._options.highlightClass) === 'string') {
+        highlightClass += (' ' + this._options.highlightClass);
+      }
+
+      if (oldHelperLayer !== null) {
+        var oldHelperNumberLayer = oldReferenceLayer.querySelector('.introjs-helperNumberLayer'),
+            oldtooltipLayer      = oldReferenceLayer.querySelector('.introjs-tooltiptext'),
+            oldArrowLayer        = oldReferenceLayer.querySelector('.introjs-arrow'),
+            oldtooltipContainer  = oldReferenceLayer.querySelector('.introjs-tooltip');
+            
+        skipTooltipButton    = oldReferenceLayer.querySelector('.introjs-skipbutton');
+        prevTooltipButton    = oldReferenceLayer.querySelector('.introjs-prevbutton');
+        nextTooltipButton    = oldReferenceLayer.querySelector('.introjs-nextbutton');
+
+        //update or reset the helper highlight class
+        oldHelperLayer.className = highlightClass;
+        //hide the tooltip
+        oldtooltipContainer.style.opacity = 0;
+        oldtooltipContainer.style.display = "none";
+
+        if (oldHelperNumberLayer !== null) {
+          var lastIntroItem = this._introItems[(targetElement.step - 2 >= 0 ? targetElement.step - 2 : 0)];
+
+          if (lastIntroItem !== null && (this._direction === 'forward' && lastIntroItem.position === 'floating') || (this._direction === 'backward' && targetElement.position === 'floating')) {
+            oldHelperNumberLayer.style.opacity = 0;
+          }
+        }
+
+        //set new position to helper layer
+        _setHelperLayerPosition.call(self, oldHelperLayer);
+        _setHelperLayerPosition.call(self, oldReferenceLayer);
+
+        //remove `introjs-fixParent` class from the elements
+        var fixParents = document.querySelectorAll('.introjs-fixParent');
+        _forEach(fixParents, function (parent) {
+          _removeClass(parent, /introjs-fixParent/g);
+        });
+        
+        //remove old classes if the element still exist
+        _removeShowElement();
+
+        //we should wait until the CSS3 transition is competed (it's 0.3 sec) to prevent incorrect `height` and `width` calculation
+        if (self._lastShowElementTimer) {
+          window.clearTimeout(self._lastShowElementTimer);
+        }
+
+        self._lastShowElementTimer = window.setTimeout(function() {
+          //set current step to the label
+          if (oldHelperNumberLayer !== null) {
+            oldHelperNumberLayer.innerHTML = targetElement.step;
+          }
+          //set current tooltip text
+          oldtooltipLayer.innerHTML = targetElement.intro;
+          //set the tooltip position
+          oldtooltipContainer.style.display = "block";
+          _placeTooltip.call(self, targetElement.element, oldtooltipContainer, oldArrowLayer, oldHelperNumberLayer);
+
+          //change active bullet
+          if (self._options.showBullets) {
+              oldReferenceLayer.querySelector('.introjs-bullets li > a.active').className = '';
+              oldReferenceLayer.querySelector('.introjs-bullets li > a[data-stepnumber="' + targetElement.step + '"]').className = 'active';
+          }
+          oldReferenceLayer.querySelector('.introjs-progress .introjs-progressbar').setAttribute('style', 'width:' + _getProgress.call(self) + '%;');
+          oldReferenceLayer.querySelector('.introjs-progress .introjs-progressbar').setAttribute('aria-valuenow', _getProgress.call(self));
+
+          //show the tooltip
+          oldtooltipContainer.style.opacity = 1;
+          if (oldHelperNumberLayer) oldHelperNumberLayer.style.opacity = 1;
+
+          //reset button focus
+          if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null && /introjs-donebutton/gi.test(skipTooltipButton.className)) {
+            // skip button is now "done" button
+            skipTooltipButton.focus();
+          } else if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
+            //still in the tour, focus on next
+            nextTooltipButton.focus();
+          }
+
+          // change the scroll of the window, if needed
+          _scrollTo.call(self, targetElement.scrollTo, targetElement, oldtooltipLayer);
+        }, 350);
+
+        // end of old element if-else condition
+      } else {
+        var helperLayer       = document.createElement('div'),
+            referenceLayer    = document.createElement('div'),
+            arrowLayer        = document.createElement('div'),
+            tooltipLayer      = document.createElement('div'),
+            tooltipTextLayer  = document.createElement('div'),
+            bulletsLayer      = document.createElement('div'),
+            progressLayer     = document.createElement('div'),
+            buttonsLayer      = document.createElement('div');
+
+        helperLayer.className = highlightClass;
+        referenceLayer.className = 'introjs-tooltipReferenceLayer';
+
+        //set new position to helper layer
+        _setHelperLayerPosition.call(self, helperLayer);
+        _setHelperLayerPosition.call(self, referenceLayer);
+
+        //add helper layer to target element
+        this._targetElement.appendChild(helperLayer);
+        this._targetElement.appendChild(referenceLayer);
+
+        arrowLayer.className = 'introjs-arrow';
+
+        tooltipTextLayer.className = 'introjs-tooltiptext';
+        tooltipTextLayer.innerHTML = targetElement.intro;
+
+        bulletsLayer.className = 'introjs-bullets';
+
+        if (this._options.showBullets === false) {
+          bulletsLayer.style.display = 'none';
+        }
+
+        var ulContainer = document.createElement('ul');
+        ulContainer.setAttribute('role', 'tablist');
+
+        var anchorClick = function () {
+            if (self._blockUserInteraction) return;
+            self.goToStep(this.getAttribute('data-stepnumber'));
+        };
+
+        _forEach(this._introItems, function (item, i) {
+          var innerLi    = document.createElement('li');
+          var anchorLink = document.createElement('a');
+          
+          innerLi.setAttribute('role', 'presentation');
+          anchorLink.setAttribute('role', 'tab');
+
+          anchorLink.onclick = anchorClick;
+
+          if (i === (targetElement.step-1)) {
+            anchorLink.className = 'active';
+          } 
+
+          _setAnchorAsButton(anchorLink);
+          anchorLink.innerHTML = "&nbsp;";
+          anchorLink.setAttribute('data-stepnumber', item.step);
+
+          innerLi.appendChild(anchorLink);
+          ulContainer.appendChild(innerLi);
+        });
+
+        bulletsLayer.appendChild(ulContainer);
+
+        progressLayer.className = 'introjs-progress';
+
+        if (this._options.showProgress === false) {
+          progressLayer.style.display = 'none';
+        }
+        var progressBar = document.createElement('div');
+        progressBar.className = 'introjs-progressbar';
+        progressBar.setAttribute('role', 'progress');
+        progressBar.setAttribute('aria-valuemin', 0);
+        progressBar.setAttribute('aria-valuemax', 100);
+        progressBar.setAttribute('aria-valuenow', _getProgress.call(this));
+        progressBar.setAttribute('style', 'width:' + _getProgress.call(this) + '%;');
+
+        progressLayer.appendChild(progressBar);
+
+        buttonsLayer.className = 'introjs-tooltipbuttons';
+        if (this._options.showButtons === false) {
+          buttonsLayer.style.display = 'none';
+        }
+
+        tooltipLayer.className = 'introjs-tooltip';
+        tooltipLayer.appendChild(tooltipTextLayer);
+        tooltipLayer.appendChild(bulletsLayer);
+        tooltipLayer.appendChild(progressLayer);
+
+        //add helper layer number
+        var helperNumberLayer = document.createElement('span');
+        if (this._options.showStepNumbers === true) {
+          helperNumberLayer.className = 'introjs-helperNumberLayer';
+          helperNumberLayer.innerHTML = targetElement.step;
+          referenceLayer.appendChild(helperNumberLayer);
+        }
+
+        tooltipLayer.appendChild(arrowLayer);
+        referenceLayer.appendChild(tooltipLayer);
+
+        //next button
+        nextTooltipButton = document.createElement('a');
+
+        nextTooltipButton.onclick = function() {
+          if (self._blockUserInteraction) return;
+          if (self._introItems.length - 1 !== self._currentStep) {
+            _nextStep.call(self);
+          }
+        };
+
+        _setAnchorAsButton(nextTooltipButton);
+        nextTooltipButton.innerHTML = this._options.nextLabel;
+
+        //previous button
+        prevTooltipButton = document.createElement('a');
+
+        prevTooltipButton.onclick = function() {
+          if (self._blockUserInteraction) return;
+          if (self._currentStep !== 0) {
+            _previousStep.call(self);
+          }
+        };
+
+        _setAnchorAsButton(prevTooltipButton);
+        prevTooltipButton.innerHTML = this._options.prevLabel;
+
+        //skip button
+        skipTooltipButton = document.createElement('a');
+        skipTooltipButton.className = 'introjs-button introjs-skipbutton';
+        _setAnchorAsButton(skipTooltipButton);
+        skipTooltipButton.innerHTML = this._options.skipLabel;
+
+        skipTooltipButton.onclick = function() {
+          if (self._blockUserInteraction) return;
+          if (self._introItems.length - 1 === self._currentStep) {
+            _executeEventListeners.call(self, EVENT_NAMES.complete, null).then(function() {
+              _exitIntro.call(self, self._targetElement);
+            });
+          } else {
+            _exitIntro.call(self, self._targetElement);
+          }
+        };
+
+        buttonsLayer.appendChild(skipTooltipButton);
+
+        //in order to prevent displaying next/previous button always
+        if (this._introItems.length > 1) {
+          buttonsLayer.appendChild(prevTooltipButton);
+          buttonsLayer.appendChild(nextTooltipButton);
+        }
+
+        tooltipLayer.appendChild(buttonsLayer);
+
+        //set proper position
+        _placeTooltip.call(self, targetElement.element, tooltipLayer, arrowLayer, helperNumberLayer);
+
+        // change the scroll of the window, if needed
+        _scrollTo.call(this, targetElement.scrollTo, targetElement, tooltipLayer);
+
+        //end of new element if-else condition
+      }
+
+      // removing previous disable interaction layer
+      var disableInteractionLayer = self._targetElement.querySelector('.introjs-disableInteraction');
       if (disableInteractionLayer) {
         disableInteractionLayer.parentNode.removeChild(disableInteractionLayer);
       }
 
-      //remove intro floating element
-      var floatingElement = document.querySelector('.introjsFloatingElement');
-      if (floatingElement) {
-        floatingElement.parentNode.removeChild(floatingElement);
+      //disable interaction
+      if (targetElement.disableInteraction) {
+        _disableInteraction.call(self);
       }
 
-      //clean listeners
-      if (window.removeEventListener) {
-        window.removeEventListener('keydown', this._onKeyDown, true);
-      } else if (document.detachEvent) { //IE
-        document.detachEvent('onkeydown', this._onKeyDown);
-      }
-
-      _executeEventListeners.call(this, EVENT_NAMES.exit, null).then(function() {
-        //set the step to zero
-        this._currentStep = undefined;
-        this._blockEventHandling = false;
-      }.bind(this));
-    }.bind(this));
-  }
-
-  /**
-   * Render tooltip box in the page
-   *
-   * @api private
-   * @method _placeTooltip
-   * @param {HTMLElement} targetElement
-   * @param {HTMLElement} tooltipLayer
-   * @param {HTMLElement} arrowLayer
-   * @param {HTMLElement} helperNumberLayer
-   * @param {Boolean} hintMode
-   */
-  function _placeTooltip(targetElement, tooltipLayer, arrowLayer, helperNumberLayer, hintMode) {
-    var tooltipCssClass = '',
-        currentStepObj,
-        tooltipOffset,
-        targetOffset,
-        windowSize,
-        currentTooltipPosition;
-
-    hintMode = hintMode || false;
-
-    //reset the old style
-    tooltipLayer.style.top        = null;
-    tooltipLayer.style.right      = null;
-    tooltipLayer.style.bottom     = null;
-    tooltipLayer.style.left       = null;
-    tooltipLayer.style.marginLeft = null;
-    tooltipLayer.style.marginTop  = null;
-
-    arrowLayer.style.display = 'inherit';
-
-    if (typeof(helperNumberLayer) !== 'undefined' && helperNumberLayer !== null) {
-      helperNumberLayer.style.top  = null;
-      helperNumberLayer.style.left = null;
-    }
-
-    //prevent error when `this._currentStep` is undefined
-    if (!this._introItems[this._currentStep]) return;
-
-    //if we have a custom css class for each step
-    currentStepObj = this._introItems[this._currentStep];
-    if (typeof (currentStepObj.tooltipClass) === 'string') {
-      tooltipCssClass = currentStepObj.tooltipClass;
-    } else {
-      tooltipCssClass = this._options.tooltipClass;
-    }
-
-    tooltipLayer.className = ('introjs-tooltip ' + tooltipCssClass).replace(/^\s+|\s+$/g, '');
-    tooltipLayer.setAttribute('role', 'dialog');
-
-    currentTooltipPosition = this._introItems[this._currentStep].position;
-
-    // Floating is always valid, no point in calculating
-    if (currentTooltipPosition !== "floating") { 
-      currentTooltipPosition = _determineAutoPosition.call(this, targetElement, tooltipLayer, currentTooltipPosition);
-    }
-
-    var tooltipLayerStyleLeft;
-    targetOffset  = _getOffset(targetElement);
-    tooltipOffset = _getOffset(tooltipLayer);
-    windowSize    = _getWinSize();
-
-    _addClass(tooltipLayer, 'introjs-' + currentTooltipPosition);
-
-    switch (currentTooltipPosition) {
-      case 'top-right-aligned':
-        arrowLayer.className      = 'introjs-arrow bottom-right';
-
-        var tooltipLayerStyleRight = 0;
-        _checkLeft(targetOffset, tooltipLayerStyleRight, tooltipOffset, tooltipLayer);
-        tooltipLayer.style.bottom    = (targetOffset.height +  20) + 'px';
-        break;
-
-      case 'top-middle-aligned':
-        arrowLayer.className      = 'introjs-arrow bottom-middle';
-
-        var tooltipLayerStyleLeftRight = targetOffset.width / 2 - tooltipOffset.width / 2;
-
-        // a fix for middle aligned hints
-        if (hintMode) {
-          tooltipLayerStyleLeftRight += 5;
-        }
-
-        if (_checkLeft(targetOffset, tooltipLayerStyleLeftRight, tooltipOffset, tooltipLayer)) {
-          tooltipLayer.style.right = null;
-          _checkRight(targetOffset, tooltipLayerStyleLeftRight, tooltipOffset, windowSize, tooltipLayer);
-        }
-        tooltipLayer.style.bottom = (targetOffset.height + 20) + 'px';
-        break;
-
-      case 'top-left-aligned':
-      // top-left-aligned is the same as the default top
-      case POSITIONS.TOP:
-        arrowLayer.className = 'introjs-arrow bottom';
-
-        tooltipLayerStyleLeft = (hintMode) ? 0 : 15;
-
-        _checkRight(targetOffset, tooltipLayerStyleLeft, tooltipOffset, windowSize, tooltipLayer);
-        tooltipLayer.style.bottom = (targetOffset.height +  20) + 'px';
-        break;
-      case POSITIONS.RIGHT:
-        tooltipLayer.style.left = (targetOffset.width + 20) + 'px';
-        if (targetOffset.top + tooltipOffset.height > windowSize.height) {
-          // In this case, right would have fallen below the bottom of the screen.
-          // Modify so that the bottom of the tooltip connects with the target
-          arrowLayer.className = "introjs-arrow left-bottom";
-          tooltipLayer.style.top = "-" + (tooltipOffset.height - targetOffset.height - 20) + "px";
-        } else {
-          arrowLayer.className = 'introjs-arrow left';
-        }
-        break;
-      case POSITIONS.LEFT:
-        if (!hintMode && this._options.showStepNumbers === true) {
-          tooltipLayer.style.top = '15px';
-        }
-
-        if (targetOffset.top + tooltipOffset.height > windowSize.height) {
-          // In this case, left would have fallen below the bottom of the screen.
-          // Modify so that the bottom of the tooltip connects with the target
-          tooltipLayer.style.top = "-" + (tooltipOffset.height - targetOffset.height - 20) + "px";
-          arrowLayer.className = 'introjs-arrow right-bottom';
-        } else {
-          arrowLayer.className = 'introjs-arrow right';
-        }
-        tooltipLayer.style.right = (targetOffset.width + 20) + 'px';
-
-        break;
-      case 'floating':
-        arrowLayer.style.display = 'none';
-
-        //we have to adjust the top and left of layer manually for intro items without element
-        tooltipLayer.style.left   = '50%';
-        tooltipLayer.style.top    = '50%';
-        tooltipLayer.style.marginLeft = '-' + (tooltipOffset.width / 2)  + 'px';
-        tooltipLayer.style.marginTop  = '-' + (tooltipOffset.height / 2) + 'px';
-
-        if (typeof(helperNumberLayer) !== 'undefined' && helperNumberLayer !== null) {
-          helperNumberLayer.style.left = '-' + ((tooltipOffset.width / 2) + 18) + 'px';
-          helperNumberLayer.style.top  = '-' + ((tooltipOffset.height / 2) + 18) + 'px';
-        }
-
-        break;
-      case 'bottom-right-aligned':
-        arrowLayer.className      = 'introjs-arrow top-right';
-
-        tooltipLayerStyleRight = 0;
-        _checkLeft(targetOffset, tooltipLayerStyleRight, tooltipOffset, tooltipLayer);
-        tooltipLayer.style.top    = (targetOffset.height +  20) + 'px';
-        break;
-
-      case 'bottom-middle-aligned':
-        arrowLayer.className      = 'introjs-arrow top-middle';
-
-        tooltipLayerStyleLeftRight = targetOffset.width / 2 - tooltipOffset.width / 2;
-
-        // a fix for middle aligned hints
-        if (hintMode) {
-          tooltipLayerStyleLeftRight += 5;
-        }
-
-        if (_checkLeft(targetOffset, tooltipLayerStyleLeftRight, tooltipOffset, tooltipLayer)) {
-          tooltipLayer.style.right = null;
-          _checkRight(targetOffset, tooltipLayerStyleLeftRight, tooltipOffset, windowSize, tooltipLayer);
-        }
-        tooltipLayer.style.top = (targetOffset.height + 20) + 'px';
-        break;
-
-      // case 'bottom-left-aligned':
-      // Bottom-left-aligned is the same as the default bottom
-      // case 'bottom':
-      // Bottom going to follow the default behavior
-      default:
-        arrowLayer.className = 'introjs-arrow top';
-
-        tooltipLayerStyleLeft = 0;
-        _checkRight(targetOffset, tooltipLayerStyleLeft, tooltipOffset, windowSize, tooltipLayer);
-        tooltipLayer.style.top    = (targetOffset.height +  20) + 'px';
-    }
-  }
-
-  /**
-   * Set tooltip left so it doesn't go off the right side of the window
-   *
-   * @return boolean true, if tooltipLayerStyleLeft is ok.  false, otherwise.
-   */
-  function _checkRight(targetOffset, tooltipLayerStyleLeft, tooltipOffset, windowSize, tooltipLayer) {
-    if (targetOffset.left + tooltipLayerStyleLeft + tooltipOffset.width > windowSize.width) {
-      // off the right side of the window
-      tooltipLayer.style.left = (windowSize.width - tooltipOffset.width - targetOffset.left) + 'px';
-      return false;
-    }
-    tooltipLayer.style.left = tooltipLayerStyleLeft + 'px';
-    return true;
-  }
-
-  /**
-   * Set tooltip right so it doesn't go off the left side of the window
-   *
-   * @return boolean true, if tooltipLayerStyleRight is ok.  false, otherwise.
-   */
-  function _checkLeft(targetOffset, tooltipLayerStyleRight, tooltipOffset, tooltipLayer) {
-    if (targetOffset.left + targetOffset.width - tooltipLayerStyleRight - tooltipOffset.width < 0) {
-      // off the left side of the window
-      tooltipLayer.style.left = (-targetOffset.left) + 'px';
-      return false;
-    }
-    tooltipLayer.style.right = tooltipLayerStyleRight + 'px';
-    return true;
-  }
-
-  /**
-   * Determines the position of the tooltip based on the position precedence and availability
-   * of screen space.
-   *
-   * @param {Object}    targetElement
-   * @param {Object}    tooltipLayer
-   * @param {String}    desiredTooltipPosition
-   * @return {String}   calculatedPosition
-   */
-  function _determineAutoPosition(targetElement, tooltipLayer, desiredTooltipPosition) {
-
-    // Take a clone of position precedence. These will be the available
-    var possiblePositions = this._options.positionPrecedence.slice();
-
-    var windowSize = _getWinSize();
-    var tooltipHeight = _getOffset(tooltipLayer).height + 10;
-    var tooltipWidth = _getOffset(tooltipLayer).width + 20;
-    var targetElementRect = targetElement.getBoundingClientRect();
-
-    // If we check all the possible areas, and there are no valid places for the tooltip, the element
-    // must take up most of the screen real estate. Show the tooltip floating in the middle of the screen.
-    var calculatedPosition = "floating";
-
-    /*
-    * auto determine position 
-    */
-
-    // Check for space below
-    if (targetElementRect.bottom + tooltipHeight + tooltipHeight > windowSize.height) {
-      _removeEntry(possiblePositions, POSITIONS.BOTTOM);
-    }
-
-    // Check for space above
-    if (targetElementRect.top - tooltipHeight < 0) {
-      _removeEntry(possiblePositions, POSITIONS.TOP);
-    }
-
-    // Check for space to the right
-    if (targetElementRect.right + tooltipWidth > windowSize.width) {
-      _removeEntry(possiblePositions, POSITIONS.RIGHT);
-    }
-
-    // Check for space to the left
-    if (targetElementRect.left - tooltipWidth < 0) {
-      _removeEntry(possiblePositions, POSITIONS.LEFT);
-    }
-
-    // @var {String}  ex: 'right-aligned'
-    var desiredAlignment = (function (pos) {
-      var hyphenIndex = pos.indexOf('-');
-      if (hyphenIndex !== -1) {
-        // has alignment
-        return pos.substr(hyphenIndex);
-      }
-      return '';
-    })(desiredTooltipPosition || '');
-
-    // strip alignment from position
-    if (desiredTooltipPosition) {
-      // ex: "bottom-right-aligned"
-      // should return 'bottom'
-      desiredTooltipPosition = desiredTooltipPosition.split('-')[0];
-    }
-
-    if (possiblePositions.length) {
-      if (desiredTooltipPosition !== "auto" &&
-          possiblePositions.indexOf(desiredTooltipPosition) > -1) {
-        // If the requested position is in the list, choose that
-        calculatedPosition = desiredTooltipPosition;
-      } else {
-        // Pick the first valid position, in order
-        calculatedPosition = possiblePositions[0];
-      }
-    }
-
-    // only top and bottom positions have optional alignments
-    if ([POSITIONS.TOP, POSITIONS.BOTTOM].indexOf(calculatedPosition) !== -1) {
-      calculatedPosition += _determineAutoAlignment(targetElementRect.left, tooltipWidth, windowSize, desiredAlignment);
-    }
-
-    return calculatedPosition;
-  }
-
-  /**
-  * auto-determine alignment
-  * @param {Integer}  offsetLeft
-  * @param {Integer}  tooltipWidth
-  * @param {Object}   windowSize
-  * @param {String}   desiredAlignment
-  * @return {String}  calculatedAlignment
-  */
-  function _determineAutoAlignment (offsetLeft, tooltipWidth, windowSize, desiredAlignment) {
-    var halfTooltipWidth = tooltipWidth / 2,
-      winWidth = Math.min(windowSize.width, window.screen.width),
-      possibleAlignments = ['-left-aligned', '-middle-aligned', '-right-aligned'],
-      calculatedAlignment = '';
-    
-    // valid left must be at least a tooltipWidth
-    // away from right side
-    if (winWidth - offsetLeft < tooltipWidth) {
-      _removeEntry(possibleAlignments, '-left-aligned');
-    }
-
-    // valid middle must be at least half 
-    // width away from both sides
-    if (offsetLeft < halfTooltipWidth || 
-      winWidth - offsetLeft < halfTooltipWidth) {
-      _removeEntry(possibleAlignments, '-middle-aligned');
-    }
-
-    // valid right must be at least a tooltipWidth
-    // width away from left side
-    if (offsetLeft < tooltipWidth) {
-      _removeEntry(possibleAlignments, '-right-aligned');
-    }
-
-    if (possibleAlignments.length) {
-      if (possibleAlignments.indexOf(desiredAlignment) !== -1) {
-        // the desired alignment is valid
-        calculatedAlignment = desiredAlignment;
-      } else {
-        // pick the first valid position, in order
-        calculatedAlignment = possibleAlignments[0];
-      }
-    } else {
-      // if screen width is too small 
-      // for ANY alignment, middle is 
-      // probably the best for visibility
-      calculatedAlignment = '-middle-aligned';
-    }
-
-    return calculatedAlignment;
-  }
-
-  /**
-   * Remove an entry from a string array if it's there, does nothing if it isn't there.
-   *
-   * @param {Array} stringArray
-   * @param {String} stringToRemove
-   */
-  function _removeEntry(stringArray, stringToRemove) {
-    if (stringArray.indexOf(stringToRemove) > -1) {
-      stringArray.splice(stringArray.indexOf(stringToRemove), 1);
-    }
-  }
-
-  /**
-   * Update the position of the helper layer on the screen
-   *
-   * @api private
-   * @method _setHelperLayerPosition
-   * @param {Object} helperLayer
-   */
-  function _setHelperLayerPosition(helperLayer) {
-    if (helperLayer) {
-      //prevent error when `this._currentStep` in undefined
-      if (!this._introItems[this._currentStep]) return;
-
-      var currentElement  = this._introItems[this._currentStep],
-          elementPosition = _getOffset(currentElement.element),
-          widthHeightPadding = this._options.helperElementPadding;
-
-      // If the target element is fixed, the tooltip should be fixed as well.
-      // Otherwise, remove a fixed class that may be left over from the previous
-      // step.
-      if (_isFixed(currentElement.element)) {
-        _addClass(helperLayer, 'introjs-fixedTooltip');
-      } else {
-        _removeClass(helperLayer, 'introjs-fixedTooltip');
-      }
-
-      if (currentElement.position === 'floating') {
-        widthHeightPadding = 0;
-      }
-
-      //set new position to helper layer
-      helperLayer.setAttribute('style', 'width: ' + (elementPosition.width  + widthHeightPadding)  + 'px; ' +
-                                        'height:' + (elementPosition.height + widthHeightPadding)  + 'px; ' +
-                                        'top:'    + (elementPosition.top    - widthHeightPadding / 2)   + 'px;' +
-                                        'left: '  + (elementPosition.left   - widthHeightPadding / 2)   + 'px;');
-
-    }
-  }
-
-  /**
-   * Add disableinteraction layer and adjust the size and position of the layer
-   *
-   * @api private
-   * @method _disableInteraction
-   */
-  function _disableInteraction() {
-    var disableInteractionLayer = document.querySelector('.introjs-disableInteraction');
-
-    if (disableInteractionLayer === null) {
-      disableInteractionLayer = document.createElement('div');
-      disableInteractionLayer.className = 'introjs-disableInteraction';
-      this._targetElement.appendChild(disableInteractionLayer);
-    }
-
-    _setHelperLayerPosition.call(this, disableInteractionLayer);
-  }
-
-  /**
-   * Setting anchors to behave like buttons
-   *
-   * @api private
-   * @method _setAnchorAsButton
-   */
-  function _setAnchorAsButton(anchor){
-    anchor.setAttribute('role', 'button');
-    anchor.tabIndex = 0;
-  }
-
-  /**
-   * Show an element on the page
-   *
-   * @api private
-   * @method _showElement
-   * @param {Object} targetElement
-   */
-  function _showElement(targetElement) {
-    _executeEventListeners.call(this, EVENT_NAMES.change, null, targetElement.element).then(
-      function() {
-        var self = this,
-            oldHelperLayer = document.querySelector('.introjs-helperLayer'),
-            oldReferenceLayer = document.querySelector('.introjs-tooltipReferenceLayer'),
-            highlightClass = 'introjs-helperLayer',
-            nextTooltipButton,
-            prevTooltipButton,
-            skipTooltipButton;
-
-        //check for a current step highlight class
-        if (typeof (targetElement.highlightClass) === 'string') {
-          highlightClass += (' ' + targetElement.highlightClass);
-        }
-        //check for options highlight class
-        if (typeof (this._options.highlightClass) === 'string') {
-          highlightClass += (' ' + this._options.highlightClass);
-        }
-
-        if (oldHelperLayer !== null) {
-          var oldHelperNumberLayer = oldReferenceLayer.querySelector('.introjs-helperNumberLayer'),
-              oldtooltipLayer      = oldReferenceLayer.querySelector('.introjs-tooltiptext'),
-              oldArrowLayer        = oldReferenceLayer.querySelector('.introjs-arrow'),
-              oldtooltipContainer  = oldReferenceLayer.querySelector('.introjs-tooltip');
-              
-          skipTooltipButton    = oldReferenceLayer.querySelector('.introjs-skipbutton');
-          prevTooltipButton    = oldReferenceLayer.querySelector('.introjs-prevbutton');
-          nextTooltipButton    = oldReferenceLayer.querySelector('.introjs-nextbutton');
-
-          //update or reset the helper highlight class
-          oldHelperLayer.className = highlightClass;
-          //hide the tooltip
-          oldtooltipContainer.style.opacity = 0;
-          oldtooltipContainer.style.display = "none";
-
-          if (oldHelperNumberLayer !== null) {
-            var lastIntroItem = this._introItems[(targetElement.step - 2 >= 0 ? targetElement.step - 2 : 0)];
-
-            if (lastIntroItem !== null && (this._direction === 'forward' && lastIntroItem.position === 'floating') || (this._direction === 'backward' && targetElement.position === 'floating')) {
-              oldHelperNumberLayer.style.opacity = 0;
-            }
-          }
-
-          //set new position to helper layer
-          _setHelperLayerPosition.call(self, oldHelperLayer);
-          _setHelperLayerPosition.call(self, oldReferenceLayer);
-
-          //remove `introjs-fixParent` class from the elements
-          var fixParents = document.querySelectorAll('.introjs-fixParent');
-          _forEach(fixParents, function (parent) {
-            _removeClass(parent, /introjs-fixParent/g);
-          });
-          
-          //remove old classes if the element still exist
-          _removeShowElement();
-
-          //we should wait until the CSS3 transition is competed (it's 0.3 sec) to prevent incorrect `height` and `width` calculation
-          if (self._lastShowElementTimer) {
-            window.clearTimeout(self._lastShowElementTimer);
-          }
-
-          self._lastShowElementTimer = window.setTimeout(function() {
-            //set current step to the label
-            if (oldHelperNumberLayer !== null) {
-              oldHelperNumberLayer.innerHTML = targetElement.step;
-            }
-            //set current tooltip text
-            oldtooltipLayer.innerHTML = targetElement.intro;
-            //set the tooltip position
-            oldtooltipContainer.style.display = "block";
-            _placeTooltip.call(self, targetElement.element, oldtooltipContainer, oldArrowLayer, oldHelperNumberLayer);
-
-            //change active bullet
-            if (self._options.showBullets) {
-                oldReferenceLayer.querySelector('.introjs-bullets li > a.active').className = '';
-                oldReferenceLayer.querySelector('.introjs-bullets li > a[data-stepnumber="' + targetElement.step + '"]').className = 'active';
-            }
-            oldReferenceLayer.querySelector('.introjs-progress .introjs-progressbar').setAttribute('style', 'width:' + _getProgress.call(self) + '%;');
-            oldReferenceLayer.querySelector('.introjs-progress .introjs-progressbar').setAttribute('aria-valuenow', _getProgress.call(self));
-
-            //show the tooltip
-            oldtooltipContainer.style.opacity = 1;
-            if (oldHelperNumberLayer) oldHelperNumberLayer.style.opacity = 1;
-
-            //reset button focus
-            if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null && /introjs-donebutton/gi.test(skipTooltipButton.className)) {
-              // skip button is now "done" button
-              skipTooltipButton.focus();
-            } else if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
-              //still in the tour, focus on next
-              nextTooltipButton.focus();
-            }
-
-            // change the scroll of the window, if needed
-            _scrollTo.call(self, targetElement.scrollTo, targetElement, oldtooltipLayer);
-          }, 350);
-
-          // end of old element if-else condition
-        } else {
-          var helperLayer       = document.createElement('div'),
-              referenceLayer    = document.createElement('div'),
-              arrowLayer        = document.createElement('div'),
-              tooltipLayer      = document.createElement('div'),
-              tooltipTextLayer  = document.createElement('div'),
-              bulletsLayer      = document.createElement('div'),
-              progressLayer     = document.createElement('div'),
-              buttonsLayer      = document.createElement('div');
-
-          helperLayer.className = highlightClass;
-          referenceLayer.className = 'introjs-tooltipReferenceLayer';
-
-          // change the scroll of the window, if needed
-          _scrollTo.call(self, targetElement.scrollTo, targetElement, oldtooltipLayer);
-
-          //set new position to helper layer
-          _setHelperLayerPosition.call(self, oldHelperLayer);
-          _setHelperLayerPosition.call(self, oldReferenceLayer);
-
-          _setStepsOverlayPosition.call(self, targetElement);
-
-          //add helper layer to target element
-          this._targetElement.appendChild(helperLayer);
-          this._targetElement.appendChild(referenceLayer);
-          
-          arrowLayer.className = 'introjs-arrow';
-
-          tooltipTextLayer.className = 'introjs-tooltiptext';
-          tooltipTextLayer.innerHTML = targetElement.intro;
-
-          bulletsLayer.className = 'introjs-bullets';
-
-          if (this._options.showBullets === false) {
-            bulletsLayer.style.display = 'none';
-          }
-
-          var ulContainer = document.createElement('ul');
-          ulContainer.setAttribute('role', 'tablist');
-
-          var anchorClick = function () {
-              if (self._blockUserInteraction) return;
-              self.goToStep(this.getAttribute('data-stepnumber'));
-          };
-
-          _forEach(this._introItems, function (item, i) {
-            var innerLi    = document.createElement('li');
-            var anchorLink = document.createElement('a');
-            
-            innerLi.setAttribute('role', 'presentation');
-            anchorLink.setAttribute('role', 'tab');
-
-            anchorLink.onclick = anchorClick;
-
-            if (i === (targetElement.step-1)) {
-              anchorLink.className = 'active';
-            } 
-
-            _setAnchorAsButton(anchorLink);
-            anchorLink.innerHTML = "&nbsp;";
-            anchorLink.setAttribute('data-stepnumber', item.step);
-
-            innerLi.appendChild(anchorLink);
-            ulContainer.appendChild(innerLi);
-          });
-
-          bulletsLayer.appendChild(ulContainer);
-
-          progressLayer.className = 'introjs-progress';
-
-          if (this._options.showProgress === false) {
-            progressLayer.style.display = 'none';
-          }
-          var progressBar = document.createElement('div');
-          progressBar.className = 'introjs-progressbar';
-          progressBar.setAttribute('role', 'progress');
-          progressBar.setAttribute('aria-valuemin', 0);
-          progressBar.setAttribute('aria-valuemax', 100);
-          progressBar.setAttribute('aria-valuenow', _getProgress.call(this));
-          progressBar.setAttribute('style', 'width:' + _getProgress.call(this) + '%;');
-
-          progressLayer.appendChild(progressBar);
-
-          buttonsLayer.className = 'introjs-tooltipbuttons';
-          if (this._options.showButtons === false) {
-            buttonsLayer.style.display = 'none';
-          }
-
-          tooltipLayer.className = 'introjs-tooltip';
-          tooltipLayer.appendChild(tooltipTextLayer);
-          tooltipLayer.appendChild(bulletsLayer);
-          tooltipLayer.appendChild(progressLayer);
-
-          //add helper layer number
-          var helperNumberLayer = document.createElement('span');
-          if (this._options.showStepNumbers === true) {
-            helperNumberLayer.className = 'introjs-helperNumberLayer';
-            helperNumberLayer.innerHTML = targetElement.step;
-            referenceLayer.appendChild(helperNumberLayer);
-          }
-
-          tooltipLayer.appendChild(arrowLayer);
-          referenceLayer.appendChild(tooltipLayer);
-
-          //next button
-          nextTooltipButton = document.createElement('a');
-
-          nextTooltipButton.onclick = function() {
-            if (self._blockUserInteraction) return;
-            if (self._introItems.length - 1 !== self._currentStep) {
-              _nextStep.call(self);
-            }
-          };
-
-          _setAnchorAsButton(nextTooltipButton);
-          nextTooltipButton.innerHTML = this._options.nextLabel;
-
-          //previous button
-          prevTooltipButton = document.createElement('a');
-
-          prevTooltipButton.onclick = function() {
-            if (self._blockUserInteraction) return;
-            if (self._currentStep !== 0) {
-              _previousStep.call(self);
-            }
-          };
-
-          _setAnchorAsButton(prevTooltipButton);
-          prevTooltipButton.innerHTML = this._options.prevLabel;
-
-          //skip button
-          skipTooltipButton = document.createElement('a');
+      // when it's the first step of tour
+      if (this._currentStep === 0 && this._introItems.length > 1) {
+        if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
           skipTooltipButton.className = 'introjs-button introjs-skipbutton';
-          _setAnchorAsButton(skipTooltipButton);
-          skipTooltipButton.innerHTML = this._options.skipLabel;
-
-          skipTooltipButton.onclick = function() {
-            if (self._blockUserInteraction) return;
-            if (self._introItems.length - 1 === self._currentStep) {
-              _executeEventListeners.call(self, EVENT_NAMES.complete, null).then(function() {
-                _exitIntro.call(self, self._targetElement);
-              });
-            } else {
-              _exitIntro.call(self, self._targetElement);
-            }
-          };
-
-          buttonsLayer.appendChild(skipTooltipButton);
-
-          //in order to prevent displaying next/previous button always
-          if (this._introItems.length > 1) {
-            buttonsLayer.appendChild(prevTooltipButton);
-            buttonsLayer.appendChild(nextTooltipButton);
-          }
-
-          tooltipLayer.appendChild(buttonsLayer);
-
-          //set proper position
-          _placeTooltip.call(self, targetElement.element, tooltipLayer, arrowLayer, helperNumberLayer);
-
-          // change the scroll of the window, if needed
-          _scrollTo.call(this, targetElement.scrollTo, targetElement, tooltipLayer);
-
-          //end of new element if-else condition
+        }
+        if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
+          nextTooltipButton.className = 'introjs-button introjs-nextbutton';
         }
 
-        // removing previous disable interaction layer
-        var disableInteractionLayer = self._targetElement.querySelector('.introjs-disableInteraction');
-        if (disableInteractionLayer) {
-          disableInteractionLayer.parentNode.removeChild(disableInteractionLayer);
-        }
-
-        //disable interaction
-        if (targetElement.disableInteraction) {
-          _disableInteraction.call(self);
-        }
-        
-        // when it's the first step of tour
-        if (this._currentStep === 0 && this._introItems.length > 1) {
-          if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
-            skipTooltipButton.className = 'introjs-button introjs-skipbutton';
+        if (this._options.hidePrev === true) {
+          if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
+            prevTooltipButton.className = 'introjs-button introjs-prevbutton introjs-hidden';
           }
           if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
-            nextTooltipButton.className = 'introjs-button introjs-nextbutton';
-          }
-
-          if (this._options.hidePrev === true) {
-            if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
-              prevTooltipButton.className = 'introjs-button introjs-prevbutton introjs-hidden';
-            }
-            if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
-              _addClass(nextTooltipButton, 'introjs-fullbutton');
-            }
-          } else {
-            if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
-              prevTooltipButton.className = 'introjs-button introjs-prevbutton introjs-disabled';
-            }
-          }
-
-          if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
-            skipTooltipButton.innerHTML = this._options.skipLabel;
-          }
-        } else if (this._introItems.length - 1 === this._currentStep || this._introItems.length === 1) {
-          // last step of tour
-          if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
-            skipTooltipButton.innerHTML = this._options.doneLabel;
-            // adding donebutton class in addition to skipbutton
-            _addClass(skipTooltipButton, 'introjs-donebutton');
-          }
-          if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
-            prevTooltipButton.className = 'introjs-button introjs-prevbutton';
-          }
-
-          if (this._options.hideNext === true) {
-            if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
-              nextTooltipButton.className = 'introjs-button introjs-nextbutton introjs-hidden';
-            }
-            if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
-              _addClass(prevTooltipButton, 'introjs-fullbutton');
-            }
-          } else {
-            if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
-              nextTooltipButton.className = 'introjs-button introjs-nextbutton introjs-disabled';
-            }
+            _addClass(nextTooltipButton, 'introjs-fullbutton');
           }
         } else {
-          // steps between start and end
-          if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
-            skipTooltipButton.className = 'introjs-button introjs-skipbutton';
+          if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
+            prevTooltipButton.className = 'introjs-button introjs-prevbutton introjs-disabled';
+          }
+        }
+
+        if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
+          skipTooltipButton.innerHTML = this._options.skipLabel;
+        }
+      } else if (this._introItems.length - 1 === this._currentStep || this._introItems.length === 1) {
+        // last step of tour
+        if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
+          skipTooltipButton.innerHTML = this._options.doneLabel;
+          // adding donebutton class in addition to skipbutton
+          _addClass(skipTooltipButton, 'introjs-donebutton');
+        }
+        if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
+          prevTooltipButton.className = 'introjs-button introjs-prevbutton';
+        }
+
+        if (this._options.hideNext === true) {
+          if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
+            nextTooltipButton.className = 'introjs-button introjs-nextbutton introjs-hidden';
           }
           if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
-            prevTooltipButton.className = 'introjs-button introjs-prevbutton';
+            _addClass(prevTooltipButton, 'introjs-fullbutton');
           }
+        } else {
           if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
-            nextTooltipButton.className = 'introjs-button introjs-nextbutton';
-          }
-          if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
-            skipTooltipButton.innerHTML = this._options.skipLabel;
+            nextTooltipButton.className = 'introjs-button introjs-nextbutton introjs-disabled';
           }
         }
-
-        prevTooltipButton.setAttribute('role', 'button');
-        nextTooltipButton.setAttribute('role', 'button');
-        skipTooltipButton.setAttribute('role', 'button');
-
-        //Set focus on "next" button, so that hitting Enter always moves you onto the next step
-        if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
-          nextTooltipButton.focus();
-        }
-
-        // Call event handlers for 'afterChange'.
-        _executeEventListeners.call(this, EVENT_NAMES.afterChange, null, targetElement.element).then(
-          function () {
-            _setLayerOpacity(1);
-            // unblock user interaction
-            this._blockUserInteraction = false;
-          }.bind(this)
-        ).catch(
-          function(blockEvents) {
-            _failIntro.call(this, blockEvents);
-          }.bind(this)
-        );
-      }.bind(this),
-      function(blockEvents) {
-        _failIntro.call(this, blockEvents);
-      }.bind(this)
-    );
-  }
-
-  /**
-   * To change the scroll of `window` after highlighting an element
-   *
-   * @api private
-   * @method _scrollTo
-   * @param {String} scrollTo
-   * @param {Object} targetElement
-   * @param {Object} tooltipLayer
-   */
-  function _scrollTo(scrollTo, targetElement, tooltipLayer) {
-    if (scrollTo === 'off') return;  
-    var rect;
-
-    if (!this._options.scrollToElement) return;
-
-    if (scrollTo === 'tooltip') {
-      rect = tooltipLayer.getBoundingClientRect();
-    } else {
-      rect = targetElement.element.getBoundingClientRect();
-    }
-
-    if (!_elementInViewport(targetElement.element)) {
-      var winHeight = _getWinSize().height;
-      var top = rect.bottom - (rect.bottom - rect.top);
-
-      // TODO (afshinm): do we need scroll padding now?
-      // I have changed the scroll option and now it scrolls the window to
-      // the center of the target element or tooltip.
-
-      if (top < 0 || targetElement.element.clientHeight > winHeight) {
-        window.scrollBy(0, rect.top - ((winHeight / 2) -  (rect.height / 2)) - this._options.scrollPadding); // 30px padding from edge to look nice
-
-      //Scroll down
       } else {
-        window.scrollBy(0, rect.top - ((winHeight / 2) -  (rect.height / 2)) + this._options.scrollPadding); // 30px padding from edge to look nice
-      }
-    }
-  }
-
-  /**
-  * Iterates arrays
-  *
-  * @param {Array} arr
-  * @param {Function} forEachFnc
-  * @param {Function} completeFnc
-  * @return {Null}
-  */
-  function _forEach(arr, forEachFnc, completeFnc) {
-    // in case arr is an empty query selector node list
-    if (arr) {
-      for (var i = 0, len = arr.length; i < len; i++) {
-        forEachFnc(arr[i], i);
-      }
-    }
-
-    if (typeof(completeFnc) === 'function') {
-      completeFnc();
-    }
-  }
-
-  /**
-   * Append a class to an element
-   *
-   * @api private
-   * @method _addClass
-   * @param {Object} element
-   * @param {String} className
-   * @returns null
-   */
-  function _addClass(element, className) {
-    if (element instanceof SVGElement) {
-      // svg
-      var pre = element.getAttribute('class') || '';
-
-      element.setAttribute('class', pre + ' ' + className);
-    } else {
-      if (element.classList !== undefined) {
-        // check for modern classList property
-        var classes = className.split(' ');
-        _forEach(classes, function (cls) {
-          element.classList.add( cls );
-        });
-      } else if (!element.className.match( className )) {
-        // check if element doesn't already have className
-        element.className += ' ' + className;
-      }
-    }
-  }
-
-  /**
-   * Remove a class from an element
-   *
-   * @api private
-   * @method _removeClass
-   * @param {Object} element
-   * @param {RegExp|String} classNameRegex can be regex or string
-   * @returns null
-   */
-  function _removeClass(element, classNameRegex) {
-    if (element instanceof SVGElement) {
-      var pre = element.getAttribute('class') || '';
-
-      element.setAttribute('class', pre.replace(classNameRegex, '').replace(/^\s+|\s+$/g, ''));
-    } else {
-      element.className = element.className.replace(classNameRegex, '').replace(/^\s+|\s+$/g, '');
-    }
-  }
-
-  /**
-   * Get an element CSS property on the page
-   * Thanks to JavaScript Kit: http://www.javascriptkit.com/dhtmltutors/dhtmlcascade4.shtml
-   *
-   * @api private
-   * @method _getPropValue
-   * @param {Object} element
-   * @param {String} propName
-   * @returns Element's property value
-   */
-  function _getPropValue (element, propName) {
-    var propValue = '';
-    if (element.currentStyle) { //IE
-      propValue = element.currentStyle[propName];
-    } else if (document.defaultView && document.defaultView.getComputedStyle) { //Others
-      propValue = document.defaultView.getComputedStyle(element, null).getPropertyValue(propName);
-    }
-
-    //Prevent exception in IE
-    if (propValue && propValue.toLowerCase) {
-      return propValue.toLowerCase();
-    } else {
-      return propValue;
-    }
-  }
-
-  /**
-   * Checks to see if target element (or parents) position is fixed or not
-   *
-   * @api private
-   * @method _isFixed
-   * @param {Object} element
-   * @returns Boolean
-   */
-  function _isFixed (element) {
-    var p = element.parentNode;
-
-    if (!p || p.nodeName === 'HTML') {
-      return false;
-    }
-
-    if (_getPropValue(element, 'position') === 'fixed') {
-      return true;
-    }
-
-    return _isFixed(p);
-  }
-
-  /**
-   * Provides a cross-browser way to get the screen dimensions
-   * via: http://stackoverflow.com/questions/5864467/internet-explorer-innerheight
-   *
-   * @api private
-   * @method _getWinSize
-   * @returns {Object} width and height attributes
-   */
-  function _getWinSize() {
-    if (window.innerWidth !== undefined) {
-      return { width: window.innerWidth, height: window.innerHeight };
-    } else {
-      var D = document.documentElement;
-      return { width: D.clientWidth, height: D.clientHeight };
-    }
-  }
-
-  /**
-   * Check to see if the element is in the viewport or not
-   * http://stackoverflow.com/questions/123999/how-to-tell-if-a-dom-element-is-visible-in-the-current-viewport
-   *
-   * @api private
-   * @method _elementInViewport
-   * @param {Object} el
-   */
-  function _elementInViewport(el) {
-    var rect = el.getBoundingClientRect();
-
-    return (
-      rect.top >= 0 &&
-      rect.left >= 0 &&
-      (rect.bottom+80) <= window.innerHeight && // add 80 to get the text right
-      rect.right <= window.innerWidth
-    );
-  }
-
-  /**
-   * Add overlay layers to the page
-   *
-   * @api private
-   * @method _addOverlayLayer
-   * @param {Object} targetElm
-   */
-  function _addOverlayLayer(targetElm) {
-    var self = this;
-
-    document.body.classList.add('introjs-noscroll');
-
-    Object.getOwnPropertyNames(POSITIONS).forEach(function(key) {
-      var overlay = document.createElement("div");
-      overlay.classList.add('introjs-overlay');
-      overlay.classList.add('introjs-overlay-' + POSITIONS[key]);
-      document.body.appendChild(overlay);
-    
-      if (self._options.exitOnOverlayClick === true) {
-        overlay.onclick = function() {
-          _exitIntro.call(self, targetElm);
+        // steps between start and end
+        if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
+          skipTooltipButton.className = 'introjs-button introjs-skipbutton';
+        }
+        if (typeof prevTooltipButton !== "undefined" && prevTooltipButton !== null) {
+          prevTooltipButton.className = 'introjs-button introjs-prevbutton';
+        }
+        if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
+          nextTooltipButton.className = 'introjs-button introjs-nextbutton';
+        }
+        if (typeof skipTooltipButton !== "undefined" && skipTooltipButton !== null) {
+          skipTooltipButton.innerHTML = this._options.skipLabel;
         }
       }
-    });
 
+      prevTooltipButton.setAttribute('role', 'button');
+      nextTooltipButton.setAttribute('role', 'button');
+      skipTooltipButton.setAttribute('role', 'button');
+
+      //Set focus on "next" button, so that hitting Enter always moves you onto the next step
+      if (typeof nextTooltipButton !== "undefined" && nextTooltipButton !== null) {
+        nextTooltipButton.focus();
+      }
+
+      _setShowElement(targetElement);
+
+      // Call event handlers for 'afterChange'.
+      _executeEventListeners.call(this, EVENT_NAMES.afterChange, null, targetElement.element).then(
+        function () {
+          _setLayerOpacity(1);
+          // unblock user interaction
+          this._blockUserInteraction = false;
+        }.bind(this)
+      ).catch(
+        function(blockEvents) {
+          _failIntro.call(this, blockEvents);
+        }.bind(this)
+      );
+    }.bind(this),
+    function(blockEvents) {
+      _failIntro.call(this, blockEvents);
+    }.bind(this)
+  );
+}
+
+/**
+ * To change the scroll of `window` after highlighting an element
+ *
+ * @api private
+ * @method _scrollTo
+ * @param {String} scrollTo
+ * @param {Object} targetElement
+ * @param {Object} tooltipLayer
+ */
+function _scrollTo(scrollTo, targetElement, tooltipLayer) {
+  if (scrollTo === 'off') return;  
+  var rect;
+
+  if (!this._options.scrollToElement) return;
+
+  if (scrollTo === 'tooltip') {
+    rect = tooltipLayer.getBoundingClientRect();
+  } else {
+    rect = targetElement.element.getBoundingClientRect();
+  }
+
+  if (!_elementInViewport(targetElement.element)) {
+    var winHeight = _getWinSize().height;
+    var top = rect.bottom - (rect.bottom - rect.top);
+
+    // TODO (afshinm): do we need scroll padding now?
+    // I have changed the scroll option and now it scrolls the window to
+    // the center of the target element or tooltip.
+
+    if (top < 0 || targetElement.element.clientHeight > winHeight) {
+      window.scrollBy(0, rect.top - ((winHeight / 2) -  (rect.height / 2)) - this._options.scrollPadding); // 30px padding from edge to look nice
+
+    //Scroll down
+    } else {
+      window.scrollBy(0, rect.top - ((winHeight / 2) -  (rect.height / 2)) + this._options.scrollPadding); // 30px padding from edge to look nice
+    }
+  }
+}
+
+/**
+ * To remove all show element(s)
+ *
+ * @api private
+ * @method _removeShowElement
+ */
+function _removeShowElement() {
+  var elms = document.querySelectorAll('.introjs-showElement');
+
+  _forEach(elms, function (elm) {
+    _removeClass(elm, /introjs-[a-zA-Z]+/g);
+  });
+}
+
+/**
+ * To set the show element
+ * This function set a relative (in most cases) position and changes the z-index
+ *
+ * @api private
+ * @method _setShowElement
+ * @param {Object} targetElement
+ */
+function _setShowElement(targetElement) {
+  var parentElm;
+  // we need to add this show element class to the parent of SVG elements
+  // because the SVG elements can't have independent z-index
+  if (targetElement.element instanceof SVGElement) {
+    parentElm = targetElement.element.parentNode;
+
+    while (targetElement.element.parentNode !== null) {
+      if (!parentElm.tagName || parentElm.tagName.toLowerCase() === 'body') break;
+
+      if (parentElm.tagName.toLowerCase() === 'svg') {
+        _addClass(parentElm, 'introjs-showElement introjs-relativePosition');
+      }
+
+      parentElm = parentElm.parentNode;
+    }
+  }
+
+  _addClass(targetElement.element, 'introjs-showElement');
+
+  var currentElementPosition = _getPropValue(targetElement.element, 'position');
+  if (currentElementPosition !== 'absolute' &&
+      currentElementPosition !== 'relative' &&
+      currentElementPosition !== 'fixed') {
+    //change to new intro item
+    _addClass(targetElement.element, 'introjs-relativePosition');
+  }
+
+  parentElm = targetElement.element.parentNode;
+  while (parentElm !== null) {
+    if (!parentElm.tagName || parentElm.tagName.toLowerCase() === 'body') break;
+
+    //fix The Stacking Context problem.
+    //More detail: https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Understanding_z_index/The_stacking_context
+    var zIndex = _getPropValue(parentElm, 'z-index');
+    var opacity = parseFloat(_getPropValue(parentElm, 'opacity'));
+    var transform = _getPropValue(parentElm, 'transform') || _getPropValue(parentElm, '-webkit-transform') || _getPropValue(parentElm, '-moz-transform') || _getPropValue(parentElm, '-ms-transform') || _getPropValue(parentElm, '-o-transform');
+    if (/[0-9]+/.test(zIndex) || opacity < 1 || (transform !== 'none' && transform !== undefined)) {
+      _addClass(parentElm, 'introjs-fixParent');
+    }
+
+    parentElm = parentElm.parentNode;
+  }
+}
+
+/**
+* Iterates arrays
+*
+* @param {Array} arr
+* @param {Function} forEachFnc
+* @param {Function} completeFnc
+* @return {Null}
+*/
+function _forEach(arr, forEachFnc, completeFnc) {
+  // in case arr is an empty query selector node list
+  if (arr) {
+    for (var i = 0, len = arr.length; i < len; i++) {
+      forEachFnc(arr[i], i);
+    }
+  }
+
+  if (typeof(completeFnc) === 'function') {
+    completeFnc();
+  }
+}
+
+/**
+ * Append a class to an element
+ *
+ * @api private
+ * @method _addClass
+ * @param {Object} element
+ * @param {String} className
+ * @returns null
+ */
+function _addClass(element, className) {
+  if (element instanceof SVGElement) {
+    // svg
+    var pre = element.getAttribute('class') || '';
+
+    element.setAttribute('class', pre + ' ' + className);
+  } else {
+    if (element.classList !== undefined) {
+      // check for modern classList property
+      var classes = className.split(' ');
+      _forEach(classes, function (cls) {
+        element.classList.add( cls );
+      });
+    } else if (!element.className.match( className )) {
+      // check if element doesn't already have className
+      element.className += ' ' + className;
+    }
+  }
+}
+
+/**
+ * Remove a class from an element
+ *
+ * @api private
+ * @method _removeClass
+ * @param {Object} element
+ * @param {RegExp|String} classNameRegex can be regex or string
+ * @returns null
+ */
+function _removeClass(element, classNameRegex) {
+  if (element instanceof SVGElement) {
+    var pre = element.getAttribute('class') || '';
+
+    element.setAttribute('class', pre.replace(classNameRegex, '').replace(/^\s+|\s+$/g, ''));
+  } else {
+    element.className = element.className.replace(classNameRegex, '').replace(/^\s+|\s+$/g, '');
+  }
+}
+
+/**
+ * Get an element CSS property on the page
+ * Thanks to JavaScript Kit: http://www.javascriptkit.com/dhtmltutors/dhtmlcascade4.shtml
+ *
+ * @api private
+ * @method _getPropValue
+ * @param {Object} element
+ * @param {String} propName
+ * @returns Element's property value
+ */
+function _getPropValue (element, propName) {
+  var propValue = '';
+  if (element.currentStyle) { //IE
+    propValue = element.currentStyle[propName];
+  } else if (document.defaultView && document.defaultView.getComputedStyle) { //Others
+    propValue = document.defaultView.getComputedStyle(element, null).getPropertyValue(propName);
+  }
+
+  //Prevent exception in IE
+  if (propValue && propValue.toLowerCase) {
+    return propValue.toLowerCase();
+  } else {
+    return propValue;
+  }
+}
+
+/**
+ * Checks to see if target element (or parents) position is fixed or not
+ *
+ * @api private
+ * @method _isFixed
+ * @param {Object} element
+ * @returns Boolean
+ */
+function _isFixed (element) {
+  var p = element.parentNode;
+
+  if (!p || p.nodeName === 'HTML') {
+    return false;
+  }
+
+  if (_getPropValue(element, 'position') === 'fixed') {
     return true;
   }
 
-  /**
-   * Position and resize overlay layers
-   *
-   * @api private
-   * @method _setStepsOverlayPosition
-   * @param {Object} targetElement
-   */
-  function _setStepsOverlayPosition(targetElement) {
-    var elementDimensions = _getOffset(targetElement.element);
-    var overlayOpacity = this._options.overlayOpacity.toString();
-    var borderWidth = 1;
-  
-    //get dimensions of the document
-    var body = document.body;
-    var html = document.documentElement;
-    var documentDimensions = {
-      height: Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight),
-      width: Math.max(body.scrollWidth, body.offsetWidth, html.clientWidth, html.scrollWidth, html.offsetWidth)
-    };
-
-    //get dimensions of the intro parent element
-    var parentDimensions;
-    var overlayParent = this._targetElement;
-    var parentIsFixed = (window.getComputedStyle(overlayParent).position === "fixed");
-    if (!overlayParent.tagName || overlayParent.tagName.toLowerCase() === 'body') {
-      //if the parent element is body, use the width and height of the document, without offset  
-      parentDimensions = {
-        height: documentDimensions.height,
-        width: documentDimensions.width,
-        left: 0,
-        top: 0
-      }
-    } else {
-      var parentOffset = _getOffset(overlayParent);
-      parentDimensions = {
-          height: parentOffset.height,
-          width: parentOffset.width,
-          left: parentOffset.left,
-          top: parentOffset.top
-      }
-    }
-
-    //compute dimensions of the four overlay parts
-    var overlayDimensions = {
-      offset: {},
-      width: {},
-      height: {}
-    };
-
-    overlayDimensions.offset.left = parentDimensions.left;
-    overlayDimensions.offset.top = parentDimensions.top;
-    
-    if (targetElement.position === "floating") {
-      overlayDimensions.width.left = parentDimensions.width / 2 - parentDimensions.left;  
-      overlayDimensions.width.center = 0; 
-
-      overlayDimensions.height.top = parentDimensions.height / 2 - parentDimensions.top;
-      overlayDimensions.height.center = 0;
-    } else {
-      var topLeftPadding = (this._options.helperElementPadding / 2) - borderWidth;
-
-      overlayDimensions.width.left = elementDimensions.left - parentDimensions.left - topLeftPadding;  
-      overlayDimensions.width.center = elementDimensions.width + this._options.helperElementPadding; 
-
-      overlayDimensions.height.top = elementDimensions.top - parentDimensions.top - topLeftPadding;
-      overlayDimensions.height.center = elementDimensions.height + this._options.helperElementPadding;
-    }
-
-    overlayDimensions.width.right = parentDimensions.width - (overlayDimensions.width.left + overlayDimensions.width.center);
-    overlayDimensions.height.bottom = parentDimensions.height - (overlayDimensions.height.top + overlayDimensions.height.center); 
-
-    //compute and set the styles for the four overlays
-    Object.getOwnPropertyNames(POSITIONS).forEach(function(key) {
-      var position = POSITIONS[key];
-      var styleString = 'opacity: ' + overlayOpacity + ';';
-      if (parentIsFixed) {
-        styleString += ' position: fixed;';
-      }
-      switch (position) {
-        case POSITIONS.LEFT:
-          styleString += ' top: ' + overlayDimensions.offset.top + 'px;';
-          styleString += ' left: ' + overlayDimensions.offset.left + 'px;';
-          styleString += ' width: ' + overlayDimensions.width.left + 'px;';
-          styleString += ' height: ' + parentDimensions.height + 'px;';
-          break;
-        case POSITIONS.RIGHT:
-          styleString += ' top: ' + overlayDimensions.offset.top + 'px;';
-          styleString += ' left: ' + (overlayDimensions.offset.left + overlayDimensions.width.left + overlayDimensions.width.center) + 'px;';
-          styleString += ' width: ' + overlayDimensions.width.right + 'px;';
-          styleString += ' height: ' + parentDimensions.height + 'px;';
-          break;
-        case POSITIONS.TOP:
-          styleString += ' top: ' + overlayDimensions.offset.top + 'px;';
-          styleString += ' left: ' + (overlayDimensions.offset.left + overlayDimensions.width.left) + 'px;';
-          styleString += ' width: ' + overlayDimensions.width.center + 'px;';
-          styleString += ' height: ' + overlayDimensions.height.top + 'px;';
-          break;
-        case POSITIONS.BOTTOM:
-          styleString += ' top: ' + (overlayDimensions.offset.top + overlayDimensions.height.top + overlayDimensions.height.center) + 'px;';
-          styleString += ' left: ' + (overlayDimensions.offset.left + overlayDimensions.width.left) + 'px;';
-          styleString += ' width: ' + overlayDimensions.width.center + 'px;';
-          styleString += ' height: ' + overlayDimensions.height.bottom + 'px;';
-          break;
-      }
-      var overlay = document.getElementsByClassName('introjs-overlay-' + position)[0];
-      overlay.setAttribute('style', styleString);
-    });
-  }
-    
-  /**
-   * Removes open hint (tooltip hint)
-   *
-   * @api private
-   * @method _removeHintTooltip
-   */
-  function _removeHintTooltip() {
-    var tooltip = document.querySelector('.introjs-hintReference');
-
-    if (tooltip) {
-      var step = tooltip.getAttribute('data-step');
-      tooltip.parentNode.removeChild(tooltip);
-      return step;
-    }
-  }
-
-  /**
-   * Start parsing hint items
-   *
-   * @api private
-   * @param {Object} targetElm
-   * @method _startHint
-   */
-  function _populateHints(targetElm) {
-
-    this._introItems = [];
-
-    if (this._options.hints) {
-      _forEach(this._options.hints, function (hint) {
-        var currentItem = _cloneObject(hint);
-
-        if (typeof(currentItem.element) === 'string') {
-          //grab the element with given selector from the page
-          currentItem.element = document.querySelector(currentItem.element);
-        }
-
-        currentItem.hintPosition = currentItem.hintPosition || this._options.hintPosition;
-        currentItem.hintAnimation = currentItem.hintAnimation || this._options.hintAnimation;
-
-        if (currentItem.element !== null) {
-          this._introItems.push(currentItem);
-        }
-      }.bind(this));
-    } else {
-      var hints = targetElm.querySelectorAll('*[data-hint]');
-
-      if (!hints || !hints.length) {
-        return false;
-      }
-
-      //first add intro items with data-step
-      _forEach(hints, function (currentElement) {
-        // hint animation
-        var hintAnimation = currentElement.getAttribute('data-hintanimation');
-
-        if (hintAnimation) {
-          hintAnimation = (hintAnimation === 'true');
-        } else {
-          hintAnimation = this._options.hintAnimation;
-        }
-
-        this._introItems.push({
-          element: currentElement,
-          hint: currentElement.getAttribute('data-hint'),
-          hintPosition: currentElement.getAttribute('data-hintposition') || this._options.hintPosition,
-          hintAnimation: hintAnimation,
-          tooltipClass: currentElement.getAttribute('data-tooltipclass'),
-          position: currentElement.getAttribute('data-position') || this._options.tooltipPosition
-        });
-      }.bind(this));
-    }
-
-    _addHints.call(this);
-
-    if (document.addEventListener) {
-      document.addEventListener('click', _removeHintTooltip.bind(this), false);
-      //for window resize
-      window.addEventListener('resize', _reAlignHints.bind(this), true);
-    } else if (document.attachEvent) { //IE
-      //for window resize
-      document.attachEvent('onclick', _removeHintTooltip.bind(this));
-      document.attachEvent('onresize', _reAlignHints.bind(this));
-    }
-  }
-
-  /**
-   * Re-aligns all hint elements
-   *
-   * @api private
-   * @method _reAlignHints
-   */
-  function _reAlignHints() {
-    _forEach(this._introItems, function (item) {
-      if (typeof(item.targetElement) === 'undefined') {
-        return;
-      }
-
-      _alignHintPosition.call(this, item.hintPosition, item.element, item.targetElement);
-    }.bind(this));
-  }
-
-  /**
-  * Get a queryselector within the hint wrapper
-  *
-  * @param {String} selector
-  * @return {NodeList|Array}
-  */
-  function _hintQuerySelectorAll(selector) {
-    var hintsWrapper = document.querySelector('.introjs-hints');
-    return (hintsWrapper) ? hintsWrapper.querySelectorAll(selector) : [];
-  }
-
-  /**
-   * Hide a hint
-   *
-   * @api private
-   * @method _hideHint
-   */
-  function _hideHint(stepId) {
-    var hint = _hintQuerySelectorAll('.introjs-hint[data-step="' + stepId + '"]')[0];
-    
-    _removeHintTooltip.call(this);
-
-    if (hint) {
-      _addClass(hint, 'introjs-hidehint');
-    }
-
-    _executeEventListeners.call(this, EVENT_NAMES.hintClose, null, stepId);
-  }
-
-  /**
-   * Hide all hints
-   *
-   * @api private
-   * @method _hideHints
-   */
-  function _hideHints() {
-    var hints = _hintQuerySelectorAll('.introjs-hint');
-
-    _forEach(hints, function (hint) {
-      _hideHint.call(this, hint.getAttribute('data-step'));
-    }.bind(this));
-  }
-
-  /**
-   * Show all hints
-   *
-   * @api private
-   * @method _showHints
-   */
-  function _showHints() {
-    var hints = _hintQuerySelectorAll('.introjs-hint');
-
-    if (hints && hints.length) {
-      _forEach(hints, function (hint) {
-        _showHint.call(this, hint.getAttribute('data-step'));
-      }.bind(this));
-    } else {
-      _populateHints.call(this, this._targetElement);
-    }
-  }
-
-  /**
-   * Show a hint
-   *
-   * @api private
-   * @method _showHint
-   */
-  function _showHint(stepId) {
-    var hint = _hintQuerySelectorAll('.introjs-hint[data-step="' + stepId + '"]')[0];
-
-    if (hint) {
-      _removeClass(hint, /introjs-hidehint/g);
-    }
-  }
-
-  /**
-   * Removes all hint elements on the page
-   * Useful when you want to destroy the elements and add them again (e.g. a modal or popup)
-   *
-   * @api private
-   * @method _removeHints
-   */
-  function _removeHints() {
-    var hints = _hintQuerySelectorAll('.introjs-hint');
-
-    _forEach(hints, function (hint) {
-      _removeHint.call(this, hint.getAttribute('data-step'));
-    }.bind(this));
-  }
-
-  /**
-   * Remove one single hint element from the page
-   * Useful when you want to destroy the element and add them again (e.g. a modal or popup)
-   * Use removeHints if you want to remove all elements.
-   *
-   * @api private
-   * @method _removeHint
-   */
-  function _removeHint(stepId) {
-    var hint = _hintQuerySelectorAll('.introjs-hint[data-step="' + stepId + '"]')[0];
-
-    if (hint) {
-      hint.parentNode.removeChild(hint);
-    }
-  }
-
-  /**
-   * Add all available hints to the page
-   *
-   * @api private
-   * @method _addHints
-   */
-  function _addHints() {
-    var self = this;
-
-    var hintsWrapper = document.querySelector('.introjs-hints');
-
-    if (hintsWrapper === null) {
-      hintsWrapper = document.createElement('div');
-      hintsWrapper.className = 'introjs-hints';
-    }
-
-    /**
-    * Returns an event handler unique to the hint iteration
-    * 
-    * @param {Integer} i
-    * @return {Function}
-    */
-    var getHintClick = function (i) {
-      return function(e) {
-        var evt = e ? e : window.event;
-        
-        if (evt.stopPropagation) {
-          evt.stopPropagation();
-        }
-
-        if (evt.cancelBubble !== null) {
-          evt.cancelBubble = true;
-        }
-
-        _showHintDialog.call(self, i);
-      };
-    };
-
-    _forEach(this._introItems, function(item, i) {
-      // avoid append a hint twice
-      if (document.querySelector('.introjs-hint[data-step="' + i + '"]')) {
-        return;
-      }
-
-      var hint = document.createElement('a');
-      _setAnchorAsButton(hint);
-
-      hint.onclick = getHintClick(i);
-
-      hint.className = 'introjs-hint';
-
-      if (!item.hintAnimation) {
-        _addClass(hint, 'introjs-hint-no-anim');
-      }
-
-      // hint's position should be fixed if the target element's position is fixed
-      if (_isFixed(item.element)) {
-        _addClass(hint, 'introjs-fixedhint');
-      }
-
-      var hintDot = document.createElement('div');
-      hintDot.className = 'introjs-hint-dot';
-      var hintPulse = document.createElement('div');
-      hintPulse.className = 'introjs-hint-pulse';
-
-      hint.appendChild(hintDot);
-      hint.appendChild(hintPulse);
-      hint.setAttribute('data-step', i);
-
-      // we swap the hint element with target element
-      // because _setHelperLayerPosition uses `element` property
-      item.targetElement = item.element;
-      item.element = hint;
-
-      // align the hint position
-      _alignHintPosition.call(this, item.hintPosition, hint, item.targetElement);
-
-      hintsWrapper.appendChild(hint);
-    }.bind(this));
-
-    // adding the hints wrapper
-    document.body.appendChild(hintsWrapper);
-
-    _executeEventListeners.call(this, EVENT_NAMES.hintsAdded, null);
-  }
-
-  /**
-   * Aligns hint position
-   *
-   * @api private
-   * @method _alignHintPosition
-   * @param {String} position
-   * @param {Object} hint
-   * @param {Object} element
-   */
-  function _alignHintPosition(position, hint, element) {
-    // get/calculate offset of target element
-    var offset = _getOffset.call(this, element);
-    var iconWidth = 20;
-    var iconHeight = 20;
-
-    // align the hint element
-    switch (position) {
-      default:
-      case 'top-left':
-        hint.style.left = offset.left + 'px';
-        hint.style.top = offset.top + 'px';
-        break;
-      case 'top-right':
-        hint.style.left = (offset.left + offset.width - iconWidth) + 'px';
-        hint.style.top = offset.top + 'px';
-        break;
-      case 'bottom-left':
-        hint.style.left = offset.left + 'px';
-        hint.style.top = (offset.top + offset.height - iconHeight) + 'px';
-        break;
-      case 'bottom-right':
-        hint.style.left = (offset.left + offset.width - iconWidth) + 'px';
-        hint.style.top = (offset.top + offset.height - iconHeight) + 'px';
-        break;
-      case 'middle-left':
-        hint.style.left = offset.left + 'px';
-        hint.style.top = (offset.top + (offset.height - iconHeight) / 2) + 'px';
-        break;
-      case 'middle-right':
-        hint.style.left = (offset.left + offset.width - iconWidth) + 'px';
-        hint.style.top = (offset.top + (offset.height - iconHeight) / 2) + 'px';
-        break;
-      case 'middle-middle':
-        hint.style.left = (offset.left + (offset.width - iconWidth) / 2) + 'px';
-        hint.style.top = (offset.top + (offset.height - iconHeight) / 2) + 'px';
-        break;
-      case 'bottom-middle':
-        hint.style.left = (offset.left + (offset.width - iconWidth) / 2) + 'px';
-        hint.style.top = (offset.top + offset.height - iconHeight) + 'px';
-        break;
-      case 'top-middle':
-        hint.style.left = (offset.left + (offset.width - iconWidth) / 2) + 'px';
-        hint.style.top = offset.top + 'px';
-        break;
-    }
-  }
-
-  /**
-   * Triggers when user clicks on the hint element
-   *
-   * @api private
-   * @method _showHintDialog
-   * @param {Number} stepId
-   */
-  function _showHintDialog(stepId) {
-    var hintElement = document.querySelector('.introjs-hint[data-step="' + stepId + '"]');
-    var item = this._introItems[stepId];
-
-    _executeEventListeners.call(this, EVENT_NAMES.hintClick, null, hintElement, item, stepId).then(function() {
-      // remove all open tooltips
-      var removedStep = _removeHintTooltip.call(this);
-
-      // to toggle the tooltip
-      if (parseInt(removedStep, 10) === stepId) {
-        return;
-      }
-
-      var tooltipLayer = document.createElement('div');
-      var tooltipTextLayer = document.createElement('div');
-      var arrowLayer = document.createElement('div');
-      var referenceLayer = document.createElement('div');
-
-      tooltipLayer.className = 'introjs-tooltip';
-
-      tooltipLayer.onclick = function (e) {
-        //IE9 & Other Browsers
-        if (e.stopPropagation) {
-          e.stopPropagation();
-        }
-        //IE8 and Lower
-        else {
-          e.cancelBubble = true;
-        }
-      };
-
-      tooltipTextLayer.className = 'introjs-tooltiptext';
-
-      var tooltipWrapper = document.createElement('p');
-      tooltipWrapper.innerHTML = item.hint;
-
-      var closeButton = document.createElement('a');
-      closeButton.className = 'introjs-button';
-      closeButton.setAttribute('role', 'button');
-      closeButton.innerHTML = this._options.hintButtonLabel;
-      closeButton.onclick = _hideHint.bind(this, stepId);
-
-      tooltipTextLayer.appendChild(tooltipWrapper);
-      tooltipTextLayer.appendChild(closeButton);
-
-      arrowLayer.className = 'introjs-arrow';
-      tooltipLayer.appendChild(arrowLayer);
-
-      tooltipLayer.appendChild(tooltipTextLayer);
-
-      // set current step for _placeTooltip function
-      this._currentStep = hintElement.getAttribute('data-step');
-
-      // align reference layer position
-      referenceLayer.className = 'introjs-tooltipReferenceLayer introjs-hintReference';
-      referenceLayer.setAttribute('data-step', hintElement.getAttribute('data-step'));
-      _setHelperLayerPosition.call(this, referenceLayer);
-
-      referenceLayer.appendChild(tooltipLayer);
-      document.body.appendChild(referenceLayer);
-
-      //set proper position
-      _placeTooltip.call(this, hintElement, tooltipLayer, arrowLayer, null, true);
-
-      // make sure that the tooltip is visible
-      _setLayerOpacity(1);
-    }.bind(this));
-  }
-
-  /**
-   * Get an element position on the page
-   * Thanks to `meouw`: http://stackoverflow.com/a/442474/375966
-   *
-   * @api private
-   * @method _getOffset
-   * @param {Object} element
-   * @returns Element's position info
-   */
-  function _getOffset(element) {
-    var elementPosition = {};
-
-    var body = document.body;
-    var docEl = document.documentElement;
-
-    var scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop;
-    var scrollLeft = window.pageXOffset || docEl.scrollLeft || body.scrollLeft;
-
-    if (element instanceof SVGElement) {
-      var x = element.getBoundingClientRect();
-      elementPosition.top = x.top + scrollTop;
-      elementPosition.width = x.width;
-      elementPosition.height = x.height;
-      elementPosition.left = x.left + scrollLeft;
-    } else {
-      //set width
-      elementPosition.width = element.offsetWidth;
-
-      //set height
-      elementPosition.height = element.offsetHeight;
-
-      //calculate element top and left
-      var _x = 0;
-      var _y = 0;
-      while (element && !isNaN(element.offsetLeft) && !isNaN(element.offsetTop)) {
-        _x += element.offsetLeft;
-        _y += element.offsetTop;
-        element = element.offsetParent;
-      }
-      //set top
-      elementPosition.top = _y;
-      //set left
-      elementPosition.left = _x;
-    }
-
-    return elementPosition;
-  }
-
-  /**
-   * Gets the current progress percentage
-   *
-   * @api private
-   * @method _getProgress
-   * @returns current progress percentage
-   */
-  function _getProgress() {
-    // Steps are 0 indexed
-    var currentStep = parseInt((this._currentStep + 1), 10);
-    return ((currentStep / this._introItems.length) * 100);
-  }
-
-  /**
-   * Overwrites obj1's values with obj2's and adds obj2's if non existent in obj1
-   * via: http://stackoverflow.com/questions/171251/how-can-i-merge-properties-of-two-javascript-objects-dynamically
-   *
-   * @api private
-   * @param obj1
-   * @param obj2
-   * @returns obj3 a new object based on obj1 and obj2
-   */
-  function _mergeOptions(obj1,obj2) {
-    var obj3 = {},
-      attrname;
-    for (attrname in obj1) { obj3[attrname] = obj1[attrname]; }
-    for (attrname in obj2) { obj3[attrname] = obj2[attrname]; }
-    return obj3;
-  }
-
-  /**
-  * Exits a running intro and optionally blocks all subsequent event handling. 
-  *
-  * @method _failIntro
-  * @param {boolean|null} blockEvents Default is true
-  * @returns {undefined} 
-  */
-  function _failIntro(blockEvents) {
-    this._blockEventHandling = (typeof blockEvents === 'boolean') ? blockEvents : true;
-    _exitIntro.call(this, this._targetElement, true);
-  }
-
-  /**
-   * Set the opacity of tooltip and reference layer to a given value.
-   * Fades these layers in/out, when the intro flow is suspended by an event handler.  
-   *
-   * @api private
-   * @method _setLayerOpacity
-   * @param {Number} Opacity
-   */
-  function _setLayerOpacity(opacity) {
-    var helperLayer = document.querySelector('.introjs-helperLayer');
-    if (helperLayer) {
-      helperLayer.style.opacity = opacity;
-    }
-
-    var referenceLayer = document.querySelector('.introjs-tooltipReferenceLayer');
-    if (referenceLayer) {
-      referenceLayer.style.opacity = opacity;
-    }
-  }
-
-  // ModulePromise is either a reference to the global Promise prototype, or a simple 
-  // surrogate that resolves immediately and does nothing in the reject case.
-  // Any Promise polyfill should be provided from the outside.
-  var ModulePromise;
-  if (window && window.Promise) {
-    ModulePromise = window.Promise;
+  return _isFixed(p);
+}
+
+/**
+ * Provides a cross-browser way to get the screen dimensions
+ * via: http://stackoverflow.com/questions/5864467/internet-explorer-innerheight
+ *
+ * @api private
+ * @method _getWinSize
+ * @returns {Object} width and height attributes
+ */
+function _getWinSize() {
+  if (window.innerWidth !== undefined) {
+    return { width: window.innerWidth, height: window.innerHeight };
   } else {
-    ModulePromise = function (fn) {
-      this.resolvedValue = null;
-      fn(function(value) {
-        this.resolvedValue = value;
-      }.bind(this));
-    };
+    var D = document.documentElement;
+    return { width: D.clientWidth, height: D.clientHeight };
+  }
+}
 
-    ModulePromise.prototype.then = function (resolveFn) {
-      resolveFn(this.resolvedValue);
-      return this;
-    };
+/**
+ * Check to see if the element is in the viewport or not
+ * http://stackoverflow.com/questions/123999/how-to-tell-if-a-dom-element-is-visible-in-the-current-viewport
+ *
+ * @api private
+ * @method _elementInViewport
+ * @param {Object} el
+ */
+function _elementInViewport(el) {
+  var rect = el.getBoundingClientRect();
 
-    ModulePromise.prototype.catch = function () {
-      return this;
-    };
+  return (
+    rect.top >= 0 &&
+    rect.left >= 0 &&
+    (rect.bottom+80) <= window.innerHeight && // add 80 to get the text right
+    rect.right <= window.innerWidth
+  );
+}
 
-    ModulePromise.all = function (array) {
-      return new ModulePromise(function(resolve) {
-        resolve(array);
-      });
-    };
+/**
+ * Add overlay layer to the page
+ *
+ * @api private
+ * @method _addOverlayLayer
+ * @param {Object} targetElm
+ */
+function _addOverlayLayer(targetElm) {
+  var overlayLayer = document.createElement('div'),
+      styleText = '',
+      self = this;
+
+  //set css class name
+  overlayLayer.className = 'introjs-overlay';
+
+  //check if the target element is body, we should calculate the size of overlay layer in a better way
+  if (!targetElm.tagName || targetElm.tagName.toLowerCase() === 'body') {
+    styleText += 'top: 0;bottom: 0; left: 0;right: 0;position: fixed;';
+    overlayLayer.setAttribute('style', styleText);
+  } else {
+    //set overlay layer position
+    var elementPosition = _getOffset(targetElm);
+    if (elementPosition) {
+      styleText += 'width: ' + elementPosition.width + 'px; height:' + elementPosition.height + 'px; top:' + elementPosition.top + 'px;left: ' + elementPosition.left + 'px;';
+      overlayLayer.setAttribute('style', styleText);
+    }
   }
 
-  /**
-   * Executes all event listeners for a given event name.
-   * Returns a promise, which resolves when all promises that where returned from the 
-   * event listeners are resolved. If one of the event listener's promises rejects, then
-   * the promise rturned by this function will also reject.
-   * The event listeners can also return non-promise types, which will always be resolved.
-   *
-   * @method _executeEventListeners
-   * @param {String} eventName Canonical name of an event from EVENT_NAMES
-   * @param {Boolean|null} defaultResolvedBoolean The default boolean value for the Promise resolution, or null
-   * @returns {Promise|Object} Promise or simple object, that mimicks a Promise's then()
-   */
-  function _executeEventListeners(eventName, defaultResolvedBoolean) {
-    if (this._blockEventHandling === false) {
-      var promiseArray = [];
-      // get non-assigned parameters (Rest operator)
-      var args = [].slice.call(arguments, 2);
-      // call all event handlers and save their returned values in promiseArray
-      _forEach(this._eventHandler[eventName], function(callbackHandler) {
-        // detach callbacks that shall be called only once
-        if (callbackHandler.callOnce) {
-          this.detachEventHandler(
-            eventName,
-            callbackHandler.callbackFunction,
-            callbackHandler.callbackContext
-          );
-        }
-        // now call the event handler and save its return value
-        var returnValue = callbackHandler.callbackFunction.apply(
-          callbackHandler.callbackContext,
-          args
-        );
-        if (typeof returnValue !== 'undefined') { 
-          promiseArray.push(returnValue);
-        }
-      }.bind(this));
-      
-      if (typeof defaultResolvedBoolean === 'boolean') {
-        // if it's possible to reolve with a boolean, then return a promise
-        // that resolves after all returned booleans have been iterated
-        return new ModulePromise(function(resolve, reject) {
-          ModulePromise.all(promiseArray).then(function(values) {
-            var resolvedValue = defaultResolvedBoolean;
-            _forEach(values, function(value) {
-              if (typeof value === 'boolean' && value !== defaultResolvedBoolean) {
-                resolvedValue = value;
-              }
-            });
-            resolve(resolvedValue);
-          }, reject);
-        });
-      } else {
-        // as default, return a promise that waits until all callback promises resolve or one rejects
-        return ModulePromise.all(promiseArray);
-      }  
-    } else {
-      //in case of blocked event handling, return simple object
-      return {
-        then: function(resolve) {
-          resolve(defaultResolvedBoolean);
-        }
-      };
-    } 
+  targetElm.appendChild(overlayLayer);
+
+  overlayLayer.onclick = function() {
+    if (self._blockUserInteraction) return;
+    if (self._options.exitOnOverlayClick === true) {
+      _exitIntro.call(self, targetElm);
+    }
+  };
+
+  window.setTimeout(function() {
+    styleText += 'opacity: ' + self._options.overlayOpacity.toString() + ';';
+    overlayLayer.setAttribute('style', styleText);
+  }, 10);
+
+  return true;
+}
+
+/**
+ * Removes open hint (tooltip hint)
+ *
+ * @api private
+ * @method _removeHintTooltip
+ */
+function _removeHintTooltip() {
+  var tooltip = document.querySelector('.introjs-hintReference');
+
+  if (tooltip) {
+    var step = tooltip.getAttribute('data-step');
+    tooltip.parentNode.removeChild(tooltip);
+    return step;
   }
+}
 
-  var introJs = function (targetElm) {
-    if (typeof (targetElm) === 'object') {
-      //Ok, create a new instance
-      return new IntroJs(targetElm);
+/**
+ * Start parsing hint items
+ *
+ * @api private
+ * @param {Object} targetElm
+ * @method _startHint
+ */
+function _populateHints(targetElm) {
 
-    } else if (typeof (targetElm) === 'string') {
-      //select the target element with query selector
-      var targetElement = document.querySelector(targetElm);
+  this._introItems = [];
 
-      if (targetElement) {
-        return new IntroJs(targetElement);
-      } else {
-        throw new Error('There is no element with given selector.');
-      }
-    } else {
-      return new IntroJs(document.body);
-    }
-  };
+  if (this._options.hints) {
+    _forEach(this._options.hints, function (hint) {
+      var currentItem = _cloneObject(hint);
 
-  /**
-   * Current IntroJs version
-   *
-   * @property version
-   * @type String
-   */
-  introJs.version = VERSION;
-
-  //Prototype
-  introJs.fn = IntroJs.prototype = {
-    clone: function () {
-      return new IntroJs(this);
-    },
-    setOption: function(option, value) {
-      this._options[option] = value;
-      return this;
-    },
-    setOptions: function(options) {
-      this._options = _mergeOptions(this._options, options);
-      return this;
-    },
-    start: function () {
-      _introForElement.call(this, this._targetElement);
-      return this;
-    },
-    goToStep: function(step) {
-      _goToStep.call(this, step);
-      return this;
-    },
-    addStep: function(options) {
-      if (!this._options.steps) {
-        this._options.steps = [];
+      if (typeof(currentItem.element) === 'string') {
+        //grab the element with given selector from the page
+        currentItem.element = document.querySelector(currentItem.element);
       }
 
-      this._options.steps.push(options);
+      currentItem.hintPosition = currentItem.hintPosition || this._options.hintPosition;
+      currentItem.hintAnimation = currentItem.hintAnimation || this._options.hintAnimation;
 
-      return this;
-    },
-    addSteps: function(steps) {
-      if (!steps.length) return;
-
-      for(var index = 0; index < steps.length; index++) {
-        this.addStep(steps[index]);
-      }
-
-      return this;
-    },
-    goToStepNumber: function(step) {
-      _goToStepNumber.call(this, step);
-
-      return this;
-    },
-    nextStep: function() {
-      _nextStep.call(this);
-      return this;
-    },
-    previousStep: function() {
-      _previousStep.call(this);
-      return this;
-    },
-    exit: function(force) {
-      _exitIntro.call(this, this._targetElement, force);
-      return this;
-    },
-    refresh: function() {
-      _refresh.call(this);
-      return this;
-    },
-    addHints: function() {
-      _populateHints.call(this, this._targetElement);
-      return this;
-    },
-    hideHint: function (stepId) {
-      _hideHint.call(this, stepId);
-      return this;
-    },
-    hideHints: function () {
-      _hideHints.call(this);
-      return this;
-    },
-    showHint: function (stepId) {
-      _showHint.call(this, stepId);
-      return this;
-    },
-    showHints: function () {
-      _showHints.call(this);
-      return this;
-    },
-    removeHints: function () {
-      _removeHints.call(this);
-      return this;
-    },
-    removeHint: function (stepId) {
-      _removeHint.call(this, stepId);
-      return this;
-    },
-    showHintDialog: function (stepId) {
-      _showHintDialog.call(this, stepId);
-      return this;
-    }
-  };
-
-  // create functions for event handler registration:
-  // onEvent
-  // attachEvent
-  // attachOnceEvent
-  // detachEvent
-  _forEach(Object.getOwnPropertyNames(EVENT_NAMES), function(key) {
-    var eventName = EVENT_NAMES[key];
-    IntroJs.prototype['attach' + eventName] = (function(closureEventName) {
-      return function(callbackFunction, callbackContext) {
-        return this.attachEventHandler(
-          closureEventName,
-          callbackFunction,
-          callbackContext,
-          false
-        );
-      };
-    })(eventName);
-
-    IntroJs.prototype['attachOnce' + eventName] = (function(closureEventName) {
-      return function(callbackFunction, callbackContext) {
-        return this.attachEventHandler(
-          closureEventName,
-          callbackFunction,
-          callbackContext,
-          true
-        );
-      };
-    })(eventName);
-
-    IntroJs.prototype['detach' + eventName] = (function(closureEventName) {
-      return function(callbackFunction, callbackContext) {
-        return this.detachEventHandler(
-          closureEventName,
-          callbackFunction,
-          callbackContext
-        );
-      };
-    })(eventName);
-
-    IntroJs.prototype['on' + eventName.toLowerCase()] = (function(closureEventName) {
-      return function(callbackFunction) {
-        return this.attachEventHandler(
-          closureEventName,
-          callbackFunction,
-          null,
-          false
-        );
-      };
-    })(eventName);
-  });
-
-  IntroJs.prototype.attachEventHandler = function(
-    eventName,
-    callbackFunction,
-    callbackContext,
-    callOnce
-  ) {
-    if (typeof callbackContext === 'undefined') {
-      callbackContext = null;
-    }
-
-    if (typeof callOnce === 'undefined') {
-      callOnce = false;
-    }
-
-    if (!this._eventHandler[eventName]) {
-      throw new Error('Event literal ' + eventName + ' is not valid.');
-    } else if (typeof callbackFunction === "function") {
-      this._eventHandler[eventName].push({
-        callbackFunction: callbackFunction,
-        callbackContext: callbackContext,
-        callOnce: callOnce
-      });
-    } else {
-      throw new Error('Provided callback for ' + eventName + ' is not a function.');
-    }
-    // return a function that lets the developer directly detach the event handler
-    return function () {
-      this.detachEventHandler(eventName, callbackFunction, callbackContext);
-    }.bind(this);
-  };
-
-  IntroJs.prototype.detachEventHandler = function(
-    eventName,
-    callbackFunction,
-    callbackContext
-  ) {
-    if (typeof callbackContext === 'undefined') {
-      callbackContext = null;
-    }
-
-    if (!this._eventHandler[eventName]) {
-      throw new Error('Event literal ' + eventName + ' is not valid.');
-    }
-    _forEach(this._eventHandler[eventName], function(callbackHandler, index) {
-      if (
-        callbackHandler.callbackFunction === callbackFunction &&
-        callbackHandler.callbackContext === callbackContext
-      ) {
-        this._eventHandler[eventName].splice(index, 1);
+      if (currentItem.element !== null) {
+        this._introItems.push(currentItem);
       }
     }.bind(this));
+  } else {
+    var hints = targetElm.querySelectorAll('*[data-hint]');
+
+    if (!hints || !hints.length) {
+      return false;
+    }
+
+    //first add intro items with data-step
+    _forEach(hints, function (currentElement) {
+      // hint animation
+      var hintAnimation = currentElement.getAttribute('data-hintanimation');
+
+      if (hintAnimation) {
+        hintAnimation = (hintAnimation === 'true');
+      } else {
+        hintAnimation = this._options.hintAnimation;
+      }
+
+      this._introItems.push({
+        element: currentElement,
+        hint: currentElement.getAttribute('data-hint'),
+        hintPosition: currentElement.getAttribute('data-hintposition') || this._options.hintPosition,
+        hintAnimation: hintAnimation,
+        tooltipClass: currentElement.getAttribute('data-tooltipclass'),
+        position: currentElement.getAttribute('data-position') || this._options.tooltipPosition
+      });
+    }.bind(this));
+  }
+
+  _addHints.call(this);
+
+  if (document.addEventListener) {
+    document.addEventListener('click', _removeHintTooltip.bind(this), false);
+    //for window resize
+    window.addEventListener('resize', _reAlignHints.bind(this), true);
+  } else if (document.attachEvent) { //IE
+    //for window resize
+    document.attachEvent('onclick', _removeHintTooltip.bind(this));
+    document.attachEvent('onresize', _reAlignHints.bind(this));
+  }
+}
+
+/**
+ * Re-aligns all hint elements
+ *
+ * @api private
+ * @method _reAlignHints
+ */
+function _reAlignHints() {
+  _forEach(this._introItems, function (item) {
+    if (typeof(item.targetElement) === 'undefined') {
+      return;
+    }
+
+    _alignHintPosition.call(this, item.hintPosition, item.element, item.targetElement);
+  }.bind(this));
+}
+
+/**
+* Get a queryselector within the hint wrapper
+*
+* @param {String} selector
+* @return {NodeList|Array}
+*/
+function _hintQuerySelectorAll(selector) {
+  var hintsWrapper = document.querySelector('.introjs-hints');
+  return (hintsWrapper) ? hintsWrapper.querySelectorAll(selector) : [];
+}
+
+/**
+ * Hide a hint
+ *
+ * @api private
+ * @method _hideHint
+ */
+function _hideHint(stepId) {
+  var hint = _hintQuerySelectorAll('.introjs-hint[data-step="' + stepId + '"]')[0];
+  
+  _removeHintTooltip.call(this);
+
+  if (hint) {
+    _addClass(hint, 'introjs-hidehint');
+  }
+
+  _executeEventListeners.call(this, EVENT_NAMES.hintClose, null, stepId);
+}
+
+/**
+ * Hide all hints
+ *
+ * @api private
+ * @method _hideHints
+ */
+function _hideHints() {
+  var hints = _hintQuerySelectorAll('.introjs-hint');
+
+  _forEach(hints, function (hint) {
+    _hideHint.call(this, hint.getAttribute('data-step'));
+  }.bind(this));
+}
+
+/**
+ * Show all hints
+ *
+ * @api private
+ * @method _showHints
+ */
+function _showHints() {
+  var hints = _hintQuerySelectorAll('.introjs-hint');
+
+  if (hints && hints.length) {
+    _forEach(hints, function (hint) {
+      _showHint.call(this, hint.getAttribute('data-step'));
+    }.bind(this));
+  } else {
+    _populateHints.call(this, this._targetElement);
+  }
+}
+
+/**
+ * Show a hint
+ *
+ * @api private
+ * @method _showHint
+ */
+function _showHint(stepId) {
+  var hint = _hintQuerySelectorAll('.introjs-hint[data-step="' + stepId + '"]')[0];
+
+  if (hint) {
+    _removeClass(hint, /introjs-hidehint/g);
+  }
+}
+
+/**
+ * Removes all hint elements on the page
+ * Useful when you want to destroy the elements and add them again (e.g. a modal or popup)
+ *
+ * @api private
+ * @method _removeHints
+ */
+function _removeHints() {
+  var hints = _hintQuerySelectorAll('.introjs-hint');
+
+  _forEach(hints, function (hint) {
+    _removeHint.call(this, hint.getAttribute('data-step'));
+  }.bind(this));
+}
+
+/**
+ * Remove one single hint element from the page
+ * Useful when you want to destroy the element and add them again (e.g. a modal or popup)
+ * Use removeHints if you want to remove all elements.
+ *
+ * @api private
+ * @method _removeHint
+ */
+function _removeHint(stepId) {
+  var hint = _hintQuerySelectorAll('.introjs-hint[data-step="' + stepId + '"]')[0];
+
+  if (hint) {
+    hint.parentNode.removeChild(hint);
+  }
+}
+
+/**
+ * Add all available hints to the page
+ *
+ * @api private
+ * @method _addHints
+ */
+function _addHints() {
+  var self = this;
+
+  var hintsWrapper = document.querySelector('.introjs-hints');
+
+  if (hintsWrapper === null) {
+    hintsWrapper = document.createElement('div');
+    hintsWrapper.className = 'introjs-hints';
+  }
+
+  /**
+  * Returns an event handler unique to the hint iteration
+  * 
+  * @param {Integer} i
+  * @return {Function}
+  */
+  var getHintClick = function (i) {
+    return function(e) {
+      var evt = e ? e : window.event;
+      
+      if (evt.stopPropagation) {
+        evt.stopPropagation();
+      }
+
+      if (evt.cancelBubble !== null) {
+        evt.cancelBubble = true;
+      }
+
+      _showHintDialog.call(self, i);
+    };
+  };
+
+  _forEach(this._introItems, function(item, i) {
+    // avoid append a hint twice
+    if (document.querySelector('.introjs-hint[data-step="' + i + '"]')) {
+      return;
+    }
+
+    var hint = document.createElement('a');
+    _setAnchorAsButton(hint);
+
+    hint.onclick = getHintClick(i);
+
+    hint.className = 'introjs-hint';
+
+    if (!item.hintAnimation) {
+      _addClass(hint, 'introjs-hint-no-anim');
+    }
+
+    // hint's position should be fixed if the target element's position is fixed
+    if (_isFixed(item.element)) {
+      _addClass(hint, 'introjs-fixedhint');
+    }
+
+    var hintDot = document.createElement('div');
+    hintDot.className = 'introjs-hint-dot';
+    var hintPulse = document.createElement('div');
+    hintPulse.className = 'introjs-hint-pulse';
+
+    hint.appendChild(hintDot);
+    hint.appendChild(hintPulse);
+    hint.setAttribute('data-step', i);
+
+    // we swap the hint element with target element
+    // because _setHelperLayerPosition uses `element` property
+    item.targetElement = item.element;
+    item.element = hint;
+
+    // align the hint position
+    _alignHintPosition.call(this, item.hintPosition, hint, item.targetElement);
+
+    hintsWrapper.appendChild(hint);
+  }.bind(this));
+
+  // adding the hints wrapper
+  document.body.appendChild(hintsWrapper);
+
+  _executeEventListeners.call(this, EVENT_NAMES.hintsAdded, null);
+}
+
+/**
+ * Aligns hint position
+ *
+ * @api private
+ * @method _alignHintPosition
+ * @param {String} position
+ * @param {Object} hint
+ * @param {Object} element
+ */
+function _alignHintPosition(position, hint, element) {
+  // get/calculate offset of target element
+  var offset = _getOffset.call(this, element);
+  var iconWidth = 20;
+  var iconHeight = 20;
+
+  // align the hint element
+  switch (position) {
+    default:
+    case 'top-left':
+      hint.style.left = offset.left + 'px';
+      hint.style.top = offset.top + 'px';
+      break;
+    case 'top-right':
+      hint.style.left = (offset.left + offset.width - iconWidth) + 'px';
+      hint.style.top = offset.top + 'px';
+      break;
+    case 'bottom-left':
+      hint.style.left = offset.left + 'px';
+      hint.style.top = (offset.top + offset.height - iconHeight) + 'px';
+      break;
+    case 'bottom-right':
+      hint.style.left = (offset.left + offset.width - iconWidth) + 'px';
+      hint.style.top = (offset.top + offset.height - iconHeight) + 'px';
+      break;
+    case 'middle-left':
+      hint.style.left = offset.left + 'px';
+      hint.style.top = (offset.top + (offset.height - iconHeight) / 2) + 'px';
+      break;
+    case 'middle-right':
+      hint.style.left = (offset.left + offset.width - iconWidth) + 'px';
+      hint.style.top = (offset.top + (offset.height - iconHeight) / 2) + 'px';
+      break;
+    case 'middle-middle':
+      hint.style.left = (offset.left + (offset.width - iconWidth) / 2) + 'px';
+      hint.style.top = (offset.top + (offset.height - iconHeight) / 2) + 'px';
+      break;
+    case 'bottom-middle':
+      hint.style.left = (offset.left + (offset.width - iconWidth) / 2) + 'px';
+      hint.style.top = (offset.top + offset.height - iconHeight) + 'px';
+      break;
+    case 'top-middle':
+      hint.style.left = (offset.left + (offset.width - iconWidth) / 2) + 'px';
+      hint.style.top = offset.top + 'px';
+      break;
+  }
+}
+
+/**
+ * Triggers when user clicks on the hint element
+ *
+ * @api private
+ * @method _showHintDialog
+ * @param {Number} stepId
+ */
+function _showHintDialog(stepId) {
+  var hintElement = document.querySelector('.introjs-hint[data-step="' + stepId + '"]');
+  var item = this._introItems[stepId];
+
+  _executeEventListeners.call(this, EVENT_NAMES.hintClick, null, hintElement, item, stepId).then(function() {
+    // remove all open tooltips
+    var removedStep = _removeHintTooltip.call(this);
+
+    // to toggle the tooltip
+    if (parseInt(removedStep, 10) === stepId) {
+      return;
+    }
+
+    var tooltipLayer = document.createElement('div');
+    var tooltipTextLayer = document.createElement('div');
+    var arrowLayer = document.createElement('div');
+    var referenceLayer = document.createElement('div');
+
+    tooltipLayer.className = 'introjs-tooltip';
+
+    tooltipLayer.onclick = function (e) {
+      //IE9 & Other Browsers
+      if (e.stopPropagation) {
+        e.stopPropagation();
+      }
+      //IE8 and Lower
+      else {
+        e.cancelBubble = true;
+      }
+    };
+
+    tooltipTextLayer.className = 'introjs-tooltiptext';
+
+    var tooltipWrapper = document.createElement('p');
+    tooltipWrapper.innerHTML = item.hint;
+
+    var closeButton = document.createElement('a');
+    closeButton.className = 'introjs-button';
+    closeButton.setAttribute('role', 'button');
+    closeButton.innerHTML = this._options.hintButtonLabel;
+    closeButton.onclick = _hideHint.bind(this, stepId);
+
+    tooltipTextLayer.appendChild(tooltipWrapper);
+    tooltipTextLayer.appendChild(closeButton);
+
+    arrowLayer.className = 'introjs-arrow';
+    tooltipLayer.appendChild(arrowLayer);
+
+    tooltipLayer.appendChild(tooltipTextLayer);
+
+    // set current step for _placeTooltip function
+    this._currentStep = hintElement.getAttribute('data-step');
+
+    // align reference layer position
+    referenceLayer.className = 'introjs-tooltipReferenceLayer introjs-hintReference';
+    referenceLayer.setAttribute('data-step', hintElement.getAttribute('data-step'));
+    _setHelperLayerPosition.call(this, referenceLayer);
+
+    referenceLayer.appendChild(tooltipLayer);
+    document.body.appendChild(referenceLayer);
+
+    //set proper position
+    _placeTooltip.call(this, hintElement, tooltipLayer, arrowLayer, null, true);
+
+    // make sure that the tooltip is visible
+    _setLayerOpacity(1);
+  }.bind(this));
+}
+
+/**
+ * Get an element position on the page
+ * Thanks to `meouw`: http://stackoverflow.com/a/442474/375966
+ *
+ * @api private
+ * @method _getOffset
+ * @param {Object} element
+ * @returns Element's position info
+ */
+function _getOffset(element) {
+  var elementPosition = {};
+
+  var body = document.body;
+  var docEl = document.documentElement;
+
+  var scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop;
+  var scrollLeft = window.pageXOffset || docEl.scrollLeft || body.scrollLeft;
+
+  if (element instanceof SVGElement) {
+    var x = element.getBoundingClientRect();
+    elementPosition.top = x.top + scrollTop;
+    elementPosition.width = x.width;
+    elementPosition.height = x.height;
+    elementPosition.left = x.left + scrollLeft;
+  } else {
+    //set width
+    elementPosition.width = element.offsetWidth;
+
+    //set height
+    elementPosition.height = element.offsetHeight;
+
+    //calculate element top and left
+    var _x = 0;
+    var _y = 0;
+    while (element && !isNaN(element.offsetLeft) && !isNaN(element.offsetTop)) {
+      _x += element.offsetLeft;
+      _y += element.offsetTop;
+      element = element.offsetParent;
+    }
+    //set top
+    elementPosition.top = _y;
+    //set left
+    elementPosition.left = _x;
+  }
+
+  return elementPosition;
+}
+
+/**
+ * Gets the current progress percentage
+ *
+ * @api private
+ * @method _getProgress
+ * @returns current progress percentage
+ */
+function _getProgress() {
+  // Steps are 0 indexed
+  var currentStep = parseInt((this._currentStep + 1), 10);
+  return ((currentStep / this._introItems.length) * 100);
+}
+
+/**
+ * Overwrites obj1's values with obj2's and adds obj2's if non existent in obj1
+ * via: http://stackoverflow.com/questions/171251/how-can-i-merge-properties-of-two-javascript-objects-dynamically
+ *
+ * @api private
+ * @param obj1
+ * @param obj2
+ * @returns obj3 a new object based on obj1 and obj2
+ */
+function _mergeOptions(obj1,obj2) {
+  var obj3 = {},
+    attrname;
+  for (attrname in obj1) { obj3[attrname] = obj1[attrname]; }
+  for (attrname in obj2) { obj3[attrname] = obj2[attrname]; }
+  return obj3;
+}
+
+/**
+* Exits a running intro and optionally blocks all subsequent event handling. 
+*
+* @method _failIntro
+* @param {boolean|null} blockEvents Default is true
+* @returns {undefined} 
+*/
+function _failIntro(blockEvents) {
+  this._blockEventHandling = (typeof blockEvents === 'boolean') ? blockEvents : true;
+  _exitIntro.call(this, this._targetElement, true);
+}
+
+/**
+ * Set the opacity of tooltip and reference layer to a given value.
+ * Fades these layers in/out, when the intro flow is suspended by an event handler.  
+ *
+ * @api private
+ * @method _setLayerOpacity
+ * @param {Number} Opacity
+ */
+function _setLayerOpacity(opacity) {
+  var helperLayer = document.querySelector('.introjs-helperLayer');
+  if (helperLayer) {
+    helperLayer.style.opacity = opacity;
+  }
+
+  var referenceLayer = document.querySelector('.introjs-tooltipReferenceLayer');
+  if (referenceLayer) {
+    referenceLayer.style.opacity = opacity;
+  }
+}
+
+// ModulePromise is either a reference to the global Promise prototype, or a simple 
+// surrogate that resolves immediately and does nothing in the reject case.
+// Any Promise polyfill should be provided from the outside.
+var ModulePromise;
+if (window && window.Promise) {
+  ModulePromise = window.Promise;
+} else {
+  ModulePromise = function (fn) {
+    this.resolvedValue = null;
+    fn(function(value) {
+      this.resolvedValue = value;
+    }.bind(this));
+  };
+
+  ModulePromise.prototype.then = function (resolveFn) {
+    resolveFn(this.resolvedValue);
     return this;
   };
 
-  //expose event names, so that developers can use attach/detach directly.
-  introJs.EVENT_NAMES = EVENT_NAMES;
+  ModulePromise.prototype.catch = function () {
+    return this;
+  };
 
-  introJs.fn = IntroJs.prototype;
+  ModulePromise.all = function (array) {
+    return new ModulePromise(function(resolve) {
+      resolve(array);
+    });
+  };
+}
 
-  return introJs;
+/**
+ * Executes all event listeners for a given event name.
+ * Returns a promise, which resolves when all promises that where returned from the 
+ * event listeners are resolved. If one of the event listener's promises rejects, then
+ * the promise rturned by this function will also reject.
+ * The event listeners can also return non-promise types, which will always be resolved.
+ *
+ * @method _executeEventListeners
+ * @param {String} eventName Canonical name of an event from EVENT_NAMES
+ * @param {Boolean|null} defaultResolvedBoolean The default boolean value for the Promise resolution, or null
+ * @returns {Promise|Object} Promise or simple object, that mimicks a Promise's then()
+ */
+function _executeEventListeners(eventName, defaultResolvedBoolean) {
+  if (this._blockEventHandling === false) {
+    var promiseArray = [];
+    // get non-assigned parameters (Rest operator)
+    var args = [].slice.call(arguments, 2);
+    // call all event handlers and save their returned values in promiseArray
+    _forEach(this._eventHandler[eventName], function(callbackHandler) {
+      // detach callbacks that shall be called only once
+      if (callbackHandler.callOnce) {
+        this.detachEventHandler(
+          eventName,
+          callbackHandler.callbackFunction,
+          callbackHandler.callbackContext
+        );
+      }
+      // now call the event handler and save its return value
+      var returnValue = callbackHandler.callbackFunction.apply(
+        callbackHandler.callbackContext,
+        args
+      );
+      if (typeof returnValue !== 'undefined') { 
+        promiseArray.push(returnValue);
+      }
+    }.bind(this));
+    
+    if (typeof defaultResolvedBoolean === 'boolean') {
+      // if it's possible to reolve with a boolean, then return a promise
+      // that resolves after all returned booleans have been iterated
+      return new ModulePromise(function(resolve, reject) {
+        ModulePromise.all(promiseArray).then(function(values) {
+          var resolvedValue = defaultResolvedBoolean;
+          _forEach(values, function(value) {
+            if (typeof value === 'boolean' && value !== defaultResolvedBoolean) {
+              resolvedValue = value;
+            }
+          });
+          resolve(resolvedValue);
+        }, reject);
+      });
+    } else {
+      // as default, return a promise that waits until all callback promises resolve or one rejects
+      return ModulePromise.all(promiseArray);
+    }  
+  } else {
+    //in case of blocked event handling, return simple object
+    return {
+      then: function(resolve) {
+        resolve(defaultResolvedBoolean);
+      }
+    };
+  } 
+}
+
+var introJs = function (targetElm) {
+  if (typeof (targetElm) === 'object') {
+    //Ok, create a new instance
+    return new IntroJs(targetElm);
+
+  } else if (typeof (targetElm) === 'string') {
+    //select the target element with query selector
+    var targetElement = document.querySelector(targetElm);
+
+    if (targetElement) {
+      return new IntroJs(targetElement);
+    } else {
+      throw new Error('There is no element with given selector.');
+    }
+  } else {
+    return new IntroJs(document.body);
+  }
+};
+
+/**
+ * Current IntroJs version
+ *
+ * @property version
+ * @type String
+ */
+introJs.version = VERSION;
+
+//Prototype
+introJs.fn = IntroJs.prototype = {
+  clone: function () {
+    return new IntroJs(this);
+  },
+  setOption: function(option, value) {
+    this._options[option] = value;
+    return this;
+  },
+  setOptions: function(options) {
+    this._options = _mergeOptions(this._options, options);
+    return this;
+  },
+  start: function () {
+    _introForElement.call(this, this._targetElement);
+    return this;
+  },
+  goToStep: function(step) {
+    _goToStep.call(this, step);
+    return this;
+  },
+  addStep: function(options) {
+    if (!this._options.steps) {
+      this._options.steps = [];
+    }
+
+    this._options.steps.push(options);
+
+    return this;
+  },
+  addSteps: function(steps) {
+    if (!steps.length) return;
+
+    for(var index = 0; index < steps.length; index++) {
+      this.addStep(steps[index]);
+    }
+
+    return this;
+  },
+  goToStepNumber: function(step) {
+    _goToStepNumber.call(this, step);
+
+    return this;
+  },
+  nextStep: function() {
+    _nextStep.call(this);
+    return this;
+  },
+  previousStep: function() {
+    _previousStep.call(this);
+    return this;
+  },
+  exit: function(force) {
+    _exitIntro.call(this, this._targetElement, force);
+    return this;
+  },
+  refresh: function() {
+    _refresh.call(this);
+    return this;
+  },
+  addHints: function() {
+    _populateHints.call(this, this._targetElement);
+    return this;
+  },
+  hideHint: function (stepId) {
+    _hideHint.call(this, stepId);
+    return this;
+  },
+  hideHints: function () {
+    _hideHints.call(this);
+    return this;
+  },
+  showHint: function (stepId) {
+    _showHint.call(this, stepId);
+    return this;
+  },
+  showHints: function () {
+    _showHints.call(this);
+    return this;
+  },
+  removeHints: function () {
+    _removeHints.call(this);
+    return this;
+  },
+  removeHint: function (stepId) {
+    _removeHint.call(this, stepId);
+    return this;
+  },
+  showHintDialog: function (stepId) {
+    _showHintDialog.call(this, stepId);
+    return this;
+  }
+};
+
+// create functions for event handler registration:
+// onEvent
+// attachEvent
+// attachOnceEvent
+// detachEvent
+_forEach(Object.getOwnPropertyNames(EVENT_NAMES), function(key) {
+  var eventName = EVENT_NAMES[key];
+  IntroJs.prototype['attach' + eventName] = (function(closureEventName) {
+    return function(callbackFunction, callbackContext) {
+      return this.attachEventHandler(
+        closureEventName,
+        callbackFunction,
+        callbackContext,
+        false
+      );
+    };
+  })(eventName);
+
+  IntroJs.prototype['attachOnce' + eventName] = (function(closureEventName) {
+    return function(callbackFunction, callbackContext) {
+      return this.attachEventHandler(
+        closureEventName,
+        callbackFunction,
+        callbackContext,
+        true
+      );
+    };
+  })(eventName);
+
+  IntroJs.prototype['detach' + eventName] = (function(closureEventName) {
+    return function(callbackFunction, callbackContext) {
+      return this.detachEventHandler(
+        closureEventName,
+        callbackFunction,
+        callbackContext
+      );
+    };
+  })(eventName);
+
+  IntroJs.prototype['on' + eventName.toLowerCase()] = (function(closureEventName) {
+    return function(callbackFunction) {
+      return this.attachEventHandler(
+        closureEventName,
+        callbackFunction,
+        null,
+        false
+      );
+    };
+  })(eventName);
+});
+
+IntroJs.prototype.attachEventHandler = function(
+  eventName,
+  callbackFunction,
+  callbackContext,
+  callOnce
+) {
+  if (typeof callbackContext === 'undefined') {
+    callbackContext = null;
+  }
+
+  if (typeof callOnce === 'undefined') {
+    callOnce = false;
+  }
+
+  if (!this._eventHandler[eventName]) {
+    throw new Error('Event literal ' + eventName + ' is not valid.');
+  } else if (typeof callbackFunction === "function") {
+    this._eventHandler[eventName].push({
+      callbackFunction: callbackFunction,
+      callbackContext: callbackContext,
+      callOnce: callOnce
+    });
+  } else {
+    throw new Error('Provided callback for ' + eventName + ' is not a function.');
+  }
+  // return a function that lets the developer directly detach the event handler
+  return function () {
+    this.detachEventHandler(eventName, callbackFunction, callbackContext);
+  }.bind(this);
+};
+
+IntroJs.prototype.detachEventHandler = function(
+  eventName,
+  callbackFunction,
+  callbackContext
+) {
+  if (typeof callbackContext === 'undefined') {
+    callbackContext = null;
+  }
+
+  if (!this._eventHandler[eventName]) {
+    throw new Error('Event literal ' + eventName + ' is not valid.');
+  }
+  _forEach(this._eventHandler[eventName], function(callbackHandler, index) {
+    if (
+      callbackHandler.callbackFunction === callbackFunction &&
+      callbackHandler.callbackContext === callbackContext
+    ) {
+      this._eventHandler[eventName].splice(index, 1);
+    }
+  }.bind(this));
+  return this;
+};
+
+//expose event names, so that developers can use attach/detach directly.
+introJs.EVENT_NAMES = EVENT_NAMES;
+
+introJs.fn = IntroJs.prototype;
+
+return introJs;
 });

--- a/intro.js
+++ b/intro.js
@@ -561,6 +561,10 @@
 
     //re-align hints
     _reAlignHints.call(this);
+
+    // make tooltip and helper layer visible
+    _setLayerOpacity(1);
+
     return this;
   }
 

--- a/intro.js
+++ b/intro.js
@@ -448,26 +448,6 @@
   }
 
   /**
-   * Set the opacity of tooltip and reference layer to a given value.
-   * Fades these layers in/out, when the intro flow is suspended by an event handler.  
-   *
-   * @api private
-   * @method _setLayerOpacity
-   * @param {Number} Opacity
-   */
-  function _setLayerOpacity(opacity) {
-    var helperLayer = document.querySelector('.introjs-helperLayer');
-    if (helperLayer) {
-      helperLayer.style.opacity = opacity;
-    }
-
-    var referenceLayer = document.querySelector('.introjs-tooltipReferenceLayer');
-    if (referenceLayer) {
-      referenceLayer.style.opacity = opacity;
-    }
-  }
-
-  /**
    * Go to next step on intro
    *
    * @api private
@@ -2269,6 +2249,26 @@
     _exitIntro.call(this, this._targetElement, true);
   }
 
+  /**
+   * Set the opacity of tooltip and reference layer to a given value.
+   * Fades these layers in/out, when the intro flow is suspended by an event handler.  
+   *
+   * @api private
+   * @method _setLayerOpacity
+   * @param {Number} Opacity
+   */
+  function _setLayerOpacity(opacity) {
+    var helperLayer = document.querySelector('.introjs-helperLayer');
+    if (helperLayer) {
+      helperLayer.style.opacity = opacity;
+    }
+
+    var referenceLayer = document.querySelector('.introjs-tooltipReferenceLayer');
+    if (referenceLayer) {
+      referenceLayer.style.opacity = opacity;
+    }
+  }
+
   // ModulePromise is either a reference to the global Promise prototype, or a simple 
   // surrogate that resolves immediately and does nothing in the reject case.
   // Any Promise polyfill should be provided from the outside.
@@ -2318,6 +2318,7 @@
       var args = [].slice.call(arguments, 2);
       // call all event handlers and save their returned values in promiseArray
       _forEach(this._eventHandler[eventName], function(callbackHandler) {
+        // detach callbacks that shall be called only once
         if (callbackHandler.callOnce) {
           this.detachEventHandler(
             eventName,
@@ -2325,6 +2326,7 @@
             callbackHandler.callbackContext
           );
         }
+        // now call the event handler and save its return value
         var returnValue = callbackHandler.callbackFunction.apply(
           callbackHandler.callbackContext,
           args
@@ -2335,6 +2337,8 @@
       }.bind(this));
       
       if (typeof defaultResolvedBoolean === 'boolean') {
+        // if it's possible to reolve with a boolean, then return a promise
+        // that resolves after all returned booleans have been iterated
         return new ModulePromise(function(resolve, reject) {
           ModulePromise.all(promiseArray).then(function(values) {
             var resolvedValue = defaultResolvedBoolean;
@@ -2347,6 +2351,7 @@
           }, reject);
         });
       } else {
+        // as default, return a promise that waits until all callback promises resolve or one rejects
         return ModulePromise.all(promiseArray);
       }  
     } else {

--- a/introjs.css
+++ b/introjs.css
@@ -4,13 +4,6 @@
   z-index: 999999;
   background-color: #000;
   opacity: 0;
-  background: -moz-radial-gradient(center,ellipse cover,rgba(0,0,0,0.4) 0,rgba(0,0,0,0.9) 100%);
-  background: -webkit-gradient(radial,center center,0px,center center,100%,color-stop(0%,rgba(0,0,0,0.4)),color-stop(100%,rgba(0,0,0,0.9)));
-  background: -webkit-radial-gradient(center,ellipse cover,rgba(0,0,0,0.4) 0,rgba(0,0,0,0.9) 100%);
-  background: -o-radial-gradient(center,ellipse cover,rgba(0,0,0,0.4) 0,rgba(0,0,0,0.9) 100%);
-  background: -ms-radial-gradient(center,ellipse cover,rgba(0,0,0,0.4) 0,rgba(0,0,0,0.9) 100%);
-  background: radial-gradient(center,ellipse cover,rgba(0,0,0,0.4) 0,rgba(0,0,0,0.9) 100%);
-  filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#66000000',endColorstr='#e6000000',GradientType=1)";
   -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
   filter: alpha(opacity=50);
   -webkit-transition: all 0.3s ease-out;
@@ -20,20 +13,8 @@
           transition: all 0.3s ease-out;
 }
 
-.introjs-fixParent {
-  z-index: auto !important;
-  opacity: 1.0 !important;
-  -webkit-transform: none !important;
-     -moz-transform: none !important;
-      -ms-transform: none !important;
-       -o-transform: none !important;
-          transform: none !important;
-}
-
-.introjs-showElement,
-tr.introjs-showElement > td,
-tr.introjs-showElement > th {
-  z-index: 9999999 !important;
+.introjs-noscroll {
+  overflow: hidden;
 }
 
 .introjs-disableInteraction {
@@ -54,8 +35,6 @@ tr.introjs-showElement > th {
   box-sizing: content-box;
   position: absolute;
   z-index: 9999998;
-  background-color: #FFF;
-  background-color: rgba(255,255,255,.9);
   border: 1px solid #777;
   border: 1px solid rgba(0,0,0,.5);
   border-radius: 4px;

--- a/introjs.css
+++ b/introjs.css
@@ -60,6 +60,7 @@ tr.introjs-showElement > th {
   border: 1px solid rgba(0,0,0,.5);
   border-radius: 4px;
   box-shadow: 0 2px 15px rgba(0,0,0,.4);
+  opacity: 0;
   -webkit-transition: all 0.3s ease-out;
      -moz-transition: all 0.3s ease-out;
       -ms-transition: all 0.3s ease-out;
@@ -73,6 +74,7 @@ tr.introjs-showElement > th {
   visibility: hidden;
   z-index: 100000000;
   background-color: transparent;
+  opacity: 0;
   -webkit-transition: all 0.3s ease-out;
      -moz-transition: all 0.3s ease-out;
       -ms-transition: all 0.3s ease-out;

--- a/introjs.css
+++ b/introjs.css
@@ -4,6 +4,13 @@
   z-index: 999999;
   background-color: #000;
   opacity: 0;
+  background: -moz-radial-gradient(center,ellipse cover,rgba(0,0,0,0.4) 0,rgba(0,0,0,0.9) 100%);
+  background: -webkit-gradient(radial,center center,0px,center center,100%,color-stop(0%,rgba(0,0,0,0.4)),color-stop(100%,rgba(0,0,0,0.9)));
+  background: -webkit-radial-gradient(center,ellipse cover,rgba(0,0,0,0.4) 0,rgba(0,0,0,0.9) 100%);
+  background: -o-radial-gradient(center,ellipse cover,rgba(0,0,0,0.4) 0,rgba(0,0,0,0.9) 100%);
+  background: -ms-radial-gradient(center,ellipse cover,rgba(0,0,0,0.4) 0,rgba(0,0,0,0.9) 100%);
+  background: radial-gradient(center,ellipse cover,rgba(0,0,0,0.4) 0,rgba(0,0,0,0.9) 100%);
+  filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#66000000',endColorstr='#e6000000',GradientType=1)";
   -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
   filter: alpha(opacity=50);
   -webkit-transition: all 0.3s ease-out;
@@ -13,8 +20,20 @@
           transition: all 0.3s ease-out;
 }
 
-.introjs-noscroll {
-  overflow: hidden;
+.introjs-fixParent {
+  z-index: auto !important;
+  opacity: 1.0 !important;
+  -webkit-transform: none !important;
+     -moz-transform: none !important;
+      -ms-transform: none !important;
+       -o-transform: none !important;
+          transform: none !important;
+}
+
+.introjs-showElement,
+tr.introjs-showElement > td,
+tr.introjs-showElement > th {
+  z-index: 9999999 !important;
 }
 
 .introjs-disableInteraction {
@@ -35,6 +54,8 @@ tr.introjs-showElement > th {
   box-sizing: content-box;
   position: absolute;
   z-index: 9999998;
+  background-color: #FFF;
+  background-color: rgba(255,255,255,.9);
   border: 1px solid #777;
   border: 1px solid rgba(0,0,0,.5);
   border-radius: 4px;


### PR DESCRIPTION
There are situations where developers need to interrupt an intro's flow, e.g. to wait for a page transition to finish or a modal to render, before the next step can be shown. This PR introduces event handlers that can return promises. The promise delays the program flow until it resolves or rejects, which enables developers to finish any asynchronous task before the intro proceeds. 

Features:
- Event handlers can return any value, but only Boolean, Promise and undefined (i.e. no return statement) are processed.
- Event names are
  - Start (new, fires right before the first tooltip is shown)
  - BeforeChange (can return false to stop displaying the tooltip)
  - Change
  - AfterChange
  - Complete
  - BeforeExit (can return false to prevent exiting)
  - Exit
  - HintsAdded
  - HintClick
  - HintClose
- Introduces new methods for event handler registration. Below, 'Event' in the function signature is an event name like 'Change', and all functions are written lower camel-case:
  - `attachEvent(callbackFunction, callbackContext)`: Registers a callback function the context it should be called with. callbackContext is optional.
  - `attachOnceEvent(callbackFunction, callbackContext)`: Same as attachEvent, but the callback is excuted only once, and then automatically detached.
  - `detachEvent(callbackFunction, callbackContext)`: Removes an event handler from the callback list. Possible only if callbackFunction and callbackContext are the same references that where used when registering.
- The `attachEvent` methods return a function that can be called to deregister the event handler. This is an alternative to `detachEvent`.
- For each event, any number of listener functions can be registered. This breaks the limitation of a single callback function.
- The `onevent` functions still exist as an alternative to `attachEvent`. They are written all-lower-case. This ensures compatibility with the previous event handling framework.
- If a promise from an event handler rejects, then the intro flow is stopped.

An example is given in folder `example/multi-page-promises`.

Basic structure of event handlers:
```
intro.attachBeforeChange(beforeChange, this);

function beforeChange() {
  return new Promise(function(resolve, reject) {
      // do some asynchronous task here, then resolve or reject.
      // The event BeforeChange can resolve with a boolean, so resolve(true|false) is possible.
      // When calling reject(), the intro will stop immediately
  });
}
```
