### PR TITLE
Fix position of left arrow in modern theme

### DIFF
--- a/themes/introjs-modern.css
+++ b/themes/introjs-modern.css
@@ -47,7 +47,7 @@
 
 .introjs-arrow.left, .introjs-arrow.left-bottom {
   left: -20px;
-  border-color: rgba(000, 0, 0, 0.5) transparent transparent transparent;
+  border-color: transparent rgba(000, 0, 0, 0.5) transparent transparent;
 }
 .introjs-arrow.right, .introjs-arrow.right-bottom {
   right: -20px;


### PR DESCRIPTION
the `border-color` property is as follows
`border-color: top, right, bottom, left`
So for the left arrow, we need to set the right color.