### PR TITLE
Optionable stop click event from bubbling out of introJS layer elements

### DIFF
--- a/docs/docs/intro/options.md
+++ b/docs/docs/intro/options.md
@@ -27,6 +27,7 @@ permalink: /intro/options/
  - `scrollPadding`: Padding of scroll in px. Default is 30. Applies when `scrollToElement` is `true`
  - `overlayOpacity`: Adjust the overlay opacity, `Number` between `0` and `1`
  - `disableInteraction`: To disable interactions with elements inside the highlighted box, `true` or `false`
+ - `stopEventPropagation`: To stop click events from bubbling out of introJS layer elements, `true` or `false`
 
 ##### Adding options
 


### PR DESCRIPTION
Hi. This is my first PR so please inform me if I missed something.

**The problem:**

In an App, we have multiple drop-down menus on a single page. The menu is closed by simply clicking somewhere else, out of the area of an opened drop-down.

The issues begin when I wanted to highlight something inside the menu. When you click on next/prev/skip, drop-down closes. Which is unwanted.

The reason was click event bubbling out of introJS elements.

**The solution:**

I've created a new method `_stopEventPropagation()` for stop propagating click event out of all introJS layer elements.

And I've added option `stopEventPropagation` to activate this method (it is not active by default).
 