### PR TITLE
_scrollParentToElement was not honoring options.scrollToElement

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -1060,7 +1060,7 @@
 
       if (scrollParent !== document.body) {
         // target is within a scrollable element
-        _scrollParentToElement(scrollParent, targetElement.element);
+        _scrollParentToElement.call(self, scrollParent, targetElement.element);
       }
 
       // set new position to helper layer
@@ -1136,7 +1136,7 @@
 
       if (scrollParent !== document.body) {
         // target is within a scrollable element
-        _scrollParentToElement(scrollParent, targetElement.element);
+        _scrollParentToElement.call(self, scrollParent, targetElement.element);
       }
 
       //set new position to helper layer
@@ -2278,6 +2278,8 @@
   * @return Null
   */
   function _scrollParentToElement (parent, element) {
+    if (!this._options.scrollToElement) return;
+
     parent.scrollTop = element.offsetTop - parent.offsetTop;
   }
 


### PR DESCRIPTION
showing the tooltip for an element in scrollable div was causing the div to scroll unnecessarily.   Result is the HTML at the top of the div was no longer visible.  I added `options.scrollToElement: false` to get around this so I could manually scroll when I wanted with `onbeforechange`, but this option was not being inspected before scrolling in the `_scrollParentToElement` function.

I just grabbed the same code that is already used in `_scrollTo` and added it to `_scrollParentToElement`, and then updated the function calls to pass in `this`.