### PR TITLE
fix onbeforechange callback preventing keyboard exit

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -419,8 +419,18 @@
     }
 
     var nextStep = this._introItems[this._currentStep];
-    var continueStep = true;
 
+    if ((this._introItems.length) <= this._currentStep) {
+        //end of the intro
+        //check if any callback is defined
+        if (typeof (this._introCompleteCallback) === 'function') {
+            this._introCompleteCallback.call(this);
+        }
+        _exitIntro.call(this, this._targetElement);
+        return;
+    }
+
+    var continueStep = true;
     if (typeof (this._introBeforeChangeCallback) !== 'undefined') {
       continueStep = this._introBeforeChangeCallback.call(this, nextStep.element);
     }
@@ -429,16 +439,6 @@
     if (continueStep === false) {
       --this._currentStep;
       return false;
-    }
-
-    if ((this._introItems.length) <= this._currentStep) {
-      //end of the intro
-      //check if any callback is defined
-      if (typeof (this._introCompleteCallback) === 'function') {
-        this._introCompleteCallback.call(this);
-      }
-      _exitIntro.call(this, this._targetElement);
-      return;
     }
 
     _showElement.call(this, nextStep);


### PR DESCRIPTION
Attaching `onbeforechange` causes errors to be thrown when the intro reaches the final stage and the right arrow key is pressed. `_currentStep` continues to be incremented past the length of `_introItems`.

Take `example/callbacks/onbeforechange.html` remove the alert/return and use the right arrow key for navigation.

The check and subsequent call to the `onbeforechange` callback should occur after the `_currentStep` and `_introItems.length` comparison.