### PR TITLE
enable scrolling of a specific container

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -86,6 +86,8 @@
       scrollTo: 'element',
       /* Padding to add after scrolling when element is not in the viewport (in pixels) */
       scrollPadding: 30,
+      /* The thing to scroll */
+      scrollContainer: window,
       /* Set the overlay opacity */
       overlayOpacity: 0.8,
       /* Precedence of positions, when auto is enabled */
@@ -1063,6 +1065,9 @@
         _scrollParentToElement(scrollParent, targetElement.element);
       }
 
+      // change the scroll of the window, if needed
+      _scrollTo.call(self, targetElement.scrollTo, targetElement, oldtooltipLayer);
+
       // set new position to helper layer
       _setHelperLayerPosition.call(self, oldHelperLayer);
       _setHelperLayerPosition.call(self, oldReferenceLayer);
@@ -1113,9 +1118,7 @@
           nextTooltipButton.focus();
         }
 
-        // change the scroll of the window, if needed
-        _scrollTo.call(self, targetElement.scrollTo, targetElement, oldtooltipLayer);
-      }, 350);
+      }, 500);
 
       // end of old element if-else condition
     } else {
@@ -1408,13 +1411,16 @@
       // TODO (afshinm): do we need scroll padding now?
       // I have changed the scroll option and now it scrolls the window to
       // the center of the target element or tooltip.
+      var container = this._options.scrollContainer !== window ?
+            ? document.getElementById(this._options.scrollContainer)
+            : window;
 
       if (top < 0 || targetElement.element.clientHeight > winHeight) {
-        window.scrollBy(0, rect.top - ((winHeight / 2) -  (rect.height / 2)) - this._options.scrollPadding); // 30px padding from edge to look nice
+        container.scrollBy(0, rect.top - ((winHeight / 2) -  (rect.height / 2)) - this._options.scrollPadding); // 30px padding from edge to look nice
 
       //Scroll down
       } else {
-        window.scrollBy(0, rect.top - ((winHeight / 2) -  (rect.height / 2)) + this._options.scrollPadding); // 30px padding from edge to look nice
+        container.scrollBy(0, rect.top - ((winHeight / 2) -  (rect.height / 2)) + this._options.scrollPadding); // 30px padding from edge to look nice
       }
     }
   }

--- a/intro.js
+++ b/intro.js
@@ -1411,7 +1411,7 @@
       // TODO (afshinm): do we need scroll padding now?
       // I have changed the scroll option and now it scrolls the window to
       // the center of the target element or tooltip.
-      var container = this._options.scrollContainer !== window ?
+      var container = this._options.scrollContainer !== window 
             ? document.getElementById(this._options.scrollContainer)
             : window;
 

--- a/intro.js
+++ b/intro.js
@@ -1049,6 +1049,7 @@
       oldtooltipContainer.style.opacity = 0;
       oldtooltipContainer.style.display = "none";
 
+        /*
       if (oldHelperNumberLayer !== null) {
         var lastIntroItem = this._introItems[(targetElement.step - 2 >= 0 ? targetElement.step - 2 : 0)];
 
@@ -1056,6 +1057,7 @@
           oldHelperNumberLayer.style.opacity = 0;
         }
       }
+      */
 
       // scroll to element
       scrollParent = _getScrollParent( targetElement.element );


### PR DESCRIPTION
Hi,

I have a use case where I want to scroll a specific container rather than the whole window. This patch enables that (though I've only tested it for my use case) so sending through to you for review.

Basically, I've added an option `scrollContainer` which can be used to define an id for a specific element to scroll and moved forward the scrolling event in `_showElement` so that the scroll happens before the overlay is added (otherwise the overlay ends up in the wrong location).

I've also increased the timeout in `_showElement` from 350 to 500ms because I think it's nicer
though I understand that's total subjective. Maybe that could become an option as well?

I hope you consider adding this to the main branch.

Thanks!