### PR TITLE
Update quick-start.md

### DIFF
--- a/docs/docs/getting-started/quick-start.md
+++ b/docs/docs/getting-started/quick-start.md
@@ -22,7 +22,7 @@ For example:
 <a href='http://example.com/' data-intro='Hello step one!'></a>
 ````
 
-See all attributes [here](https://github.com/usablica/intro.js/wiki/Documentation/#attributes).
+See all attributes [here]({{site.baseurl}}/intro/attributes/).
 
 Finally, call this JavaScript function:
 


### PR DESCRIPTION
Link to attributes' doc section referenced an old doc site. Should use {{site.baseurl}} instead.