### PR TITLE
Fix "position: sticky" treatment

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -1464,6 +1464,7 @@
     var currentElementPosition = _getPropValue(targetElement.element, 'position');
     if (currentElementPosition !== 'absolute' &&
         currentElementPosition !== 'relative' &&
+        currentElementPosition !== 'sticky' &&
         currentElementPosition !== 'fixed') {
       //change to new intro item
       _addClass(targetElement.element, 'introjs-relativePosition');


### PR DESCRIPTION
Currently intro.js adds "introjs-relativePosition" class to all elements that are not positioned with "absolute", "relative" or "fixed" property value. This breaks appearance of "position: sticky" elements by overriding it with "relative". The fix mitigates the problem.