### PR TITLE
Add getCurrentStep function to public API

### DIFF
--- a/intro.js
+++ b/intro.js
@@ -2370,6 +2370,9 @@
       _introForElement.call(this, this._targetElement, group);
       return this;
     },
+    getCurrentStep: function() {
+        return this._currentStep;
+    },
     goToStep: function(step) {
       _goToStep.call(this, step);
       return this;


### PR DESCRIPTION
Currently, it is not possible to get intro.js's current step. Added a public API function for that