### PR TITLE
docs: Fix simple typo, specifing -> specifying

### DIFF
--- a/example/bootstrap/v3/vendor/jquery/jquery.js
+++ b/example/bootstrap/v3/vendor/jquery/jquery.js
@@ -7118,7 +7118,7 @@ jQuery.extend( {
 				value += ret && ret[ 3 ] || ( jQuery.cssNumber[ origName ] ? "" : "px" );
 			}
 
-			// Fixes #8908, it can be done more correctly by specifing setters in cssHooks,
+			// Fixes #8908, it can be done more correctly by specifying setters in cssHooks,
 			// but it would mean to define eight
 			// (for every problematic property) identical functions
 			if ( !support.clearCloneStyle && value === "" && name.indexOf( "background" ) === 0 ) {


### PR DESCRIPTION
There is a small typo in example/bootstrap/v3/vendor/jquery/jquery.js.

Should read `specifying` rather than `specifing`.

