### PR TITLE
Add additional class option for progressbar

### DIFF
--- a/src/core/showElement.js
+++ b/src/core/showElement.js
@@ -282,7 +282,7 @@ export default function _showElement(targetElement) {
     const progressBar = document.createElement("div");
     progressBar.className = "introjs-progressbar";
     if(this._options.progressBarAdditionalClass){
-      progressBar.className += ' ' + this._options.progressBarAdditionalClass
+      progressBar.className += ' ' + this._options.progressBarAdditionalClass;
     }
     progressBar.setAttribute("role", "progress");
     progressBar.setAttribute("aria-valuemin", 0);

--- a/src/core/showElement.js
+++ b/src/core/showElement.js
@@ -281,6 +281,9 @@ export default function _showElement(targetElement) {
     }
     const progressBar = document.createElement("div");
     progressBar.className = "introjs-progressbar";
+    if(this._options.progressBarAdditionalClass){
+      progressBar.className += ' ' + this._options.progressBarAdditionalClass
+    }
     progressBar.setAttribute("role", "progress");
     progressBar.setAttribute("aria-valuemin", 0);
     progressBar.setAttribute("aria-valuemax", 100);

--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,8 @@ function IntroJs(obj) {
     hintAnimation: true,
     /* additional classes to put on the buttons */
     buttonClass: "introjs-button",
+    /* additional classes to put on progress bar */
+    progressBarAdditionalClass: false,
   };
 }
 


### PR DESCRIPTION
Best practice to allow developers assign their theme classes to the progress bar without write weird workarounds,
I needed this and didn't found existing solution.