### PR TITLE
Custom Event handling methods as solution to circular dependencies

### DIFF
--- a/src/core/DOMEvent.js
+++ b/src/core/DOMEvent.js
@@ -16,14 +16,11 @@ const DOMEvent = (() => {
     /**
      * Gets a unique ID for an event listener
      *
-     * @param obj Object
      * @param type event type
      * @param listener Function
-     * @param context Object
      * @return String
      */
-    this._id = (obj, type, listener, context) =>
-      type + stamp(listener) + (context ? `_${stamp(context)}` : "");
+    this._id = (type, listener) => type + stamp(listener);
 
     /**
      * Adds event listener
@@ -36,7 +33,7 @@ const DOMEvent = (() => {
      * @return null
      */
     this.on = function (obj, type, listener, context, useCapture) {
-      const id = this._id.apply(this, arguments);
+      const id = this._id(type, listener);
       const handler = (e) => listener.call(context || obj, e || window.event);
 
       if ("addEventListener" in obj) {
@@ -59,8 +56,8 @@ const DOMEvent = (() => {
      * @param useCapture Boolean
      * @return null
      */
-    this.off = function (obj, type, listener, context, useCapture) {
-      const id = this._id.apply(this, arguments);
+    this.off = function (obj, type, listener, _context, useCapture) {
+      const id = this._id(type, listener);
       const handler = obj[events_key] && obj[events_key][id];
 
       if (!handler) {

--- a/src/core/IntroJs.js
+++ b/src/core/IntroJs.js
@@ -71,4 +71,4 @@ function IntroJs(obj) {
   };
 }
 
-export default IntroJs
+export default IntroJs;

--- a/src/core/IntroJs.js
+++ b/src/core/IntroJs.js
@@ -1,0 +1,74 @@
+/**
+ * IntroJs main class
+ *
+ * @class IntroJs
+ */
+function IntroJs(obj) {
+  this._targetElement = obj;
+  this._introItems = [];
+
+  this._options = {
+    /** Next button label in tooltip box */
+    nextLabel: "Next &rarr;",
+    /** Previous button label in tooltip box */
+    prevLabel: "&larr; Back",
+    /** Skip button label in tooltip box */
+    skipLabel: "Skip",
+    /** Done button label in tooltip box */
+    doneLabel: "Done",
+    /** Hide previous button in the first step? Otherwise, it will be disabled button. */
+    hidePrev: false,
+    /** Hide next button in the last step? Otherwise, it will be disabled button. */
+    hideNext: false,
+    /** Default tooltip box position */
+    tooltipPosition: "bottom",
+    /** Next CSS class for tooltip boxes */
+    tooltipClass: "",
+    /** CSS class that is added to the helperLayer */
+    highlightClass: "",
+    /** Close introduction when pressing Escape button? */
+    exitOnEsc: true,
+    /** Close introduction when clicking on overlay layer? */
+    exitOnOverlayClick: true,
+    /** Show step numbers in introduction? */
+    showStepNumbers: true,
+    /** Let user use keyboard to navigate the tour? */
+    keyboardNavigation: true,
+    /** Show tour control buttons? */
+    showButtons: true,
+    /** Show tour bullets? */
+    showBullets: true,
+    /** Show tour progress? */
+    showProgress: false,
+    /** Scroll to highlighted element? */
+    scrollToElement: true,
+    /**
+     * Should we scroll the tooltip or target element?
+     *
+     * Options are: 'element' or 'tooltip'
+     */
+    scrollTo: "element",
+    /** Padding to add after scrolling when element is not in the viewport (in pixels) */
+    scrollPadding: 30,
+    /** Set the overlay opacity */
+    overlayOpacity: 0.5,
+    /** Precedence of positions, when auto is enabled */
+    positionPrecedence: ["bottom", "top", "right", "left"],
+    /** Disable an interaction with element? */
+    disableInteraction: false,
+    /** Set how much padding to be used around helper element */
+    helperElementPadding: 10,
+    /** Default hint position */
+    hintPosition: "top-middle",
+    /** Hint button label */
+    hintButtonLabel: "Got it",
+    /** Adding animation to hints? */
+    hintAnimation: true,
+    /** additional classes to put on the buttons */
+    buttonClass: "introjs-button",
+    /** additional classes to put on progress bar */
+    progressBarAdditionalClass: false,
+  };
+}
+
+export default IntroJs

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -1,0 +1,190 @@
+/** empty function, used for gracefully removing event listeners */
+const noop = () => {};
+
+/**
+ * events: extends a class to accept custom event listener methods:
+ * (on/off/fire/once)
+ */
+export const events = {
+  /**
+   * Adds custom event listeners to an instance
+   *
+   * @param {string | Record<string, () => void>} types
+   * @param {() => void} fn
+   * @param {*} context
+   */
+  on(types, fn, context) {
+    // types can be a map of types/handlers
+    if (typeof types === "object") {
+      for (let type in types) {
+        this._on(type, types[type], fn);
+      }
+    } else {
+      this._on(types, fn, context);
+    }
+
+    return this;
+  },
+
+  /**
+   * Removes custom event listeners from an instance
+   *
+   * @param {string | Record<string, () => void>} types
+   * @param {() => void} fn
+   * @param {*} context
+   */
+  off(types, fn, context) {
+    if (!types) {
+      // clear all listeners if called without arguments
+      delete this._events;
+    } else if (typeof types === "object") {
+      for (let type in types) {
+        this._off(type, types[type], fn);
+      }
+    } else {
+      this._off(types, fn, context);
+    }
+
+    return this;
+  },
+
+  /**
+   * Internal add event listener
+   *
+   * @param {string} type
+   * @param {() => void} fn
+   * @param {*} context
+   */
+  _on(type, fn, context) {
+    this._events = this._events || {};
+
+    /* lazy initialize this._events[type] */
+    const listeners = this._events[type] || [];
+    this._events[type] = listeners;
+
+    const newListener = { fn: fn, ctx: context };
+
+    // check if fn already there
+    for (const listener of listeners) {
+      if (listener.fn === fn && listener.ctx === context) {
+        return;
+      }
+    }
+
+    listeners.push(newListener);
+  },
+
+  /** keeps track of calls to fire, so we can safely remove event listeners inside of event listeners */
+  _firingCount: 0,
+
+  /**
+   * Internal remove event listener
+   *
+   * @param {string} type
+   * @param {() => void} fn
+   * @param {*} context
+   */
+  _off(type, fn, context) {
+    if (!this._events) {
+      return;
+    }
+
+    let listeners = this._events[type] || [];
+
+    if (listeners.length === 0) {
+      return;
+    }
+
+    if (!fn) {
+      // Set all removed listeners to noop so they are not called if remove happens in fire
+      for (const listener of listeners) {
+        listener.fn = noop;
+      }
+      // clear all listeners for a type if function isn't specified
+      delete this._events[type];
+      return;
+    }
+
+    // find fn and remove it
+    for (let i = 0, len = listeners.length; i < len; i++) {
+      const listener = listeners[i];
+      if (listener.ctx === context && listener.fn === fn) {
+        // set the removed listener to noop so that's not called if remove happens in fire
+        listener.fn = noop;
+
+        if (this._firingCount) {
+          // copy array in case events are being fired
+          this._events[type] = listeners = listeners.slice();
+        }
+
+        listeners.splice(i, 1);
+
+        return;
+      }
+    }
+  },
+
+  /**
+   * Calls all event listeners that listen for a given event type
+   * @param {string} type name of event
+   * @param {*} data data to be passed to event handler
+   */
+  fire(type, data) {
+    if (!this._events || !this.listens(type)) {
+      return this;
+    }
+
+    const listeners = this._events[type] || [];
+
+    if (listeners.length > 0) {
+      const event = Object.assign({}, data, {
+        type: type,
+        target: this,
+        sourceTarget: (data && data.sourceTarget) || this,
+      });
+
+      this._firingCount++;
+      for (const listener of listeners) {
+        listener.fn.call(listener.ctx || this, event);
+      }
+      this._firingCount--;
+    }
+
+    return this;
+  },
+
+  /**
+   * Determine if an event type has any listeners
+   *
+   * @param {string} type event type
+   * @returns boolean
+   */
+  listens(type) {
+    const listeners = this._events && this._events[type];
+
+    return listeners && listeners.length > 0;
+  },
+
+  /**
+   * Adds custom event listeners to an instance which fire only once
+   *
+   * @param {string | Record<string, () => void>} types
+   * @param {() => void} fn
+   * @param {*} context
+   */
+  once(types, fn, context) {
+    if (typeof types === "object") {
+      for (const type in types) {
+        this.once(type, types[type], fn);
+      }
+      return this;
+    }
+
+    const removeFn = function () {
+      this.off(types, fn, context).off(types, removeFn, context);
+    }.bind(this);
+
+    // add a listener that's executed once and removed after that
+    return this.on(types, fn, context).on(types, removeFn, context);
+  },
+};

--- a/src/core/exitIntro.js
+++ b/src/core/exitIntro.js
@@ -1,7 +1,4 @@
 import forEach from "../util/forEach";
-import DOMEvent from "./DOMEvent";
-import onKeyDown from "./onKeyDown";
-import onResize from "./onResize";
 import removeShowElement from "./removeShowElement";
 import removeChild from "../util/removeChild";
 
@@ -9,6 +6,7 @@ import removeChild from "../util/removeChild";
  * Exit from intro
  *
  * @api private
+ * @this {import('./IntroJs').default}
  * @method _exitIntro
  * @param {Object} targetElement
  * @param {Boolean} force - Setting to `true` will skip the result of beforeExit callback
@@ -34,15 +32,6 @@ export default function exitIntro(targetElement, force) {
     forEach(overlayLayers, (overlayLayer) => removeChild(overlayLayer));
   }
 
-  //remove all helper layers
-  const helperLayer = targetElement.querySelector(".introjs-helperLayer");
-  removeChild(helperLayer, true);
-
-  const referenceLayer = targetElement.querySelector(
-    ".introjs-tooltipReferenceLayer"
-  );
-  removeChild(referenceLayer);
-
   //remove disableInteractionLayer
   const disableInteractionLayer = targetElement.querySelector(
     ".introjs-disableInteraction"
@@ -55,15 +44,13 @@ export default function exitIntro(targetElement, force) {
 
   removeShowElement();
 
-  //clean listeners
-  DOMEvent.off(window, "keydown", onKeyDown, this, true);
-  DOMEvent.off(window, "resize", onResize, this, true);
+  // signal to all listeners that introjs has exited
+  this.fire('exit');
 
-  //check if any callback is defined
+  // check if any callback is defined
   if (this._introExitCallback !== undefined) {
     this._introExitCallback.call(this);
   }
 
-  //set the step to zero
   this._currentStep = undefined;
 }

--- a/src/core/introForElement.js
+++ b/src/core/introForElement.js
@@ -2,7 +2,6 @@ import addOverlayLayer from "./addOverlayLayer";
 import cloneObject from "../util/cloneObject";
 import forEach from "../util/forEach";
 import DOMEvent from "./DOMEvent";
-import { nextStep } from "./steps";
 import onKeyDown from "./onKeyDown";
 import onResize from "./onResize";
 import createElement from "../util/createElement";
@@ -11,6 +10,7 @@ import createElement from "../util/createElement";
  * Initiate a new introduction/guide from an element in the page
  *
  * @api private
+ * @this {import('./IntroJs').default}
  * @method _introForElement
  * @param {Object} targetElm
  * @param {String} group
@@ -172,22 +172,32 @@ export default function introForElement(targetElm, group) {
 
   introItems = tempIntroItems;
 
-  //Ok, sort all items with given steps
+  // Ok, sort all items with given steps
   introItems.sort((a, b) => a.step - b.step);
 
-  //set it to the introJs object
+  // set it to the introJs object
   this._introItems = introItems;
 
-  //add overlay layer to the page
+  // add overlay layer to the page
   if (addOverlayLayer.call(this, targetElm)) {
-    //then, start the show
-    nextStep.call(this);
+    // then, start the show
+    this.nextStep();
 
     if (this._options.keyboardNavigation) {
       DOMEvent.on(window, "keydown", onKeyDown, this, true);
+      
+      this.once('exit', function removeKeyDown () {
+        DOMEvent.off(window, "keydown", onKeyDown, this, true);
+      });
     }
-    //for window resize
+    // for window resize
     DOMEvent.on(window, "resize", onResize, this, true);
+
+    this.once('exit', function removeResize () {
+      DOMEvent.off(window, "resize", onResize, this, true);
+    });
   }
+
+  // TODO: Why does this return false?
   return false;
 }

--- a/src/core/showElement.js
+++ b/src/core/showElement.js
@@ -6,18 +6,19 @@ import scrollTo from "../util/scrollTo";
 import exitIntro from "./exitIntro";
 import forEach from "../util/forEach";
 import setAnchorAsButton from "../util/setAnchorAsButton";
-import { nextStep, previousStep } from "./steps";
 import setHelperLayerPosition from "./setHelperLayerPosition";
 import placeTooltip from "./placeTooltip";
 import removeShowElement from "./removeShowElement";
 import createElement from "../util/createElement";
 import setStyle from "../util/setStyle";
 import appendChild from "../util/appendChild";
+import removeChild from "../util/removeChild";
 
 /**
  * Gets the current progress percentage
  *
  * @api private
+ * @this { import('./IntroJs').default }
  * @method _getProgress
  * @returns current progress percentage
  */
@@ -31,6 +32,7 @@ function _getProgress() {
  * Add disableinteraction layer and adjust the size and position of the layer
  *
  * @api private
+ * @this { import('./IntroJs').default }
  * @method _disableInteraction
  */
 function _disableInteraction() {
@@ -53,6 +55,7 @@ function _disableInteraction() {
  * Show an element on the page
  *
  * @api private
+ * @this { import('./IntroJs').default }
  * @method _showElement
  * @param {Object} targetElement
  */
@@ -209,12 +212,30 @@ export default function _showElement(targetElement) {
     const referenceLayer = createElement("div", {
       className: "introjs-tooltipReferenceLayer"
     });
-    const arrowLayer = createElement("div");
-    const tooltipLayer = createElement("div");
-    const tooltipTextLayer = createElement("div");
-    const bulletsLayer = createElement("div");
-    const progressLayer = createElement("div");
-    const buttonsLayer = createElement("div");
+    const arrowLayer = createElement("div", {
+      className: "introjs-arrow"
+    });
+    const tooltipLayer = createElement("div", {
+      className: "introjs-tooltip"
+    });
+    const tooltipTextLayer = createElement("div", {
+      className: "introjs-tooltiptext"
+    });
+    const bulletsLayer = createElement("div", {
+      className: "introjs-bullets"
+    });
+    const progressLayer = createElement("div", {
+      className: "introjs-progress"
+    });
+    const buttonsLayer = createElement("div", {
+      className: "introjs-tooltipbuttons"
+    });
+
+    // make sure these are cleaned up on exit
+    this.once('exit', function () {
+      removeChild(helperLayer, true);
+      removeChild(referenceLayer)
+    }, this)
 
     setStyle(helperLayer, {
       'box-shadow': `0 0 1px 2px rgba(33, 33, 33, 0.8), rgba(33, 33, 33, ${self._options.overlayOpacity.toString()}) 0 0 0 5000px`
@@ -236,12 +257,7 @@ export default function _showElement(targetElement) {
     appendChild(this._targetElement, helperLayer, true);
     appendChild(this._targetElement, referenceLayer);
 
-    arrowLayer.className = "introjs-arrow";
-
-    tooltipTextLayer.className = "introjs-tooltiptext";
     tooltipTextLayer.innerHTML = targetElement.intro;
-
-    bulletsLayer.className = "introjs-bullets";
 
     if (this._options.showBullets === false) {
       bulletsLayer.style.display = "none";
@@ -277,8 +293,6 @@ export default function _showElement(targetElement) {
 
     bulletsLayer.appendChild(ulContainer);
 
-    progressLayer.className = "introjs-progress";
-
     if (this._options.showProgress === false) {
       progressLayer.style.display = "none";
     }
@@ -298,12 +312,10 @@ export default function _showElement(targetElement) {
 
     progressLayer.appendChild(progressBar);
 
-    buttonsLayer.className = "introjs-tooltipbuttons";
     if (this._options.showButtons === false) {
       buttonsLayer.style.display = "none";
     }
 
-    tooltipLayer.className = "introjs-tooltip";
     tooltipLayer.appendChild(tooltipTextLayer);
     tooltipLayer.appendChild(bulletsLayer);
     tooltipLayer.appendChild(progressLayer);
@@ -324,8 +336,9 @@ export default function _showElement(targetElement) {
     nextTooltipButton = createElement("a");
 
     nextTooltipButton.onclick = () => {
-      if (self._introItems.length - 1 !== self._currentStep) {
-        nextStep.call(self);
+      if (this._introItems.length - 1 !== this._currentStep) {
+        // defined and bound in index.js
+        this.nextStep();
       }
     };
 
@@ -336,8 +349,9 @@ export default function _showElement(targetElement) {
     prevTooltipButton = createElement("a");
 
     prevTooltipButton.onclick = () => {
-      if (self._currentStep !== 0) {
-        previousStep.call(self);
+      if (this._currentStep !== 0) {
+        // defined and bound in index.js
+        this.previousStep();
       }
     };
 

--- a/src/core/showElement.js
+++ b/src/core/showElement.js
@@ -234,8 +234,8 @@ export default function _showElement(targetElement) {
     // make sure these are cleaned up on exit
     this.once('exit', function () {
       removeChild(helperLayer, true);
-      removeChild(referenceLayer)
-    }, this)
+      removeChild(referenceLayer);
+    }, this);
 
     setStyle(helperLayer, {
       'box-shadow': `0 0 1px 2px rgba(33, 33, 33, 0.8), rgba(33, 33, 33, ${self._options.overlayOpacity.toString()}) 0 0 0 5000px`

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import mergeOptions from "./util/mergeOptions";
 import stamp from "./util/stamp";
+import IntroJs from "./core/IntroJs";
 import exitIntro from "./core/exitIntro";
 import refresh from "./core/refresh";
 import introForElement from "./core/introForElement";
@@ -21,81 +22,14 @@ import {
   nextStep,
   previousStep,
 } from "./core/steps";
+import { events } from "./core/events";
 
 /**
- * IntroJs main class
- *
- * @class IntroJs
+ * @param {Element|string} targetElm
+ * @returns IntroJs
  */
-function IntroJs(obj) {
-  this._targetElement = obj;
-  this._introItems = [];
-
-  this._options = {
-    /* Next button label in tooltip box */
-    nextLabel: "Next &rarr;",
-    /* Previous button label in tooltip box */
-    prevLabel: "&larr; Back",
-    /* Skip button label in tooltip box */
-    skipLabel: "Skip",
-    /* Done button label in tooltip box */
-    doneLabel: "Done",
-    /* Hide previous button in the first step? Otherwise, it will be disabled button. */
-    hidePrev: false,
-    /* Hide next button in the last step? Otherwise, it will be disabled button. */
-    hideNext: false,
-    /* Default tooltip box position */
-    tooltipPosition: "bottom",
-    /* Next CSS class for tooltip boxes */
-    tooltipClass: "",
-    /* CSS class that is added to the helperLayer */
-    highlightClass: "",
-    /* Close introduction when pressing Escape button? */
-    exitOnEsc: true,
-    /* Close introduction when clicking on overlay layer? */
-    exitOnOverlayClick: true,
-    /* Show step numbers in introduction? */
-    showStepNumbers: true,
-    /* Let user use keyboard to navigate the tour? */
-    keyboardNavigation: true,
-    /* Show tour control buttons? */
-    showButtons: true,
-    /* Show tour bullets? */
-    showBullets: true,
-    /* Show tour progress? */
-    showProgress: false,
-    /* Scroll to highlighted element? */
-    scrollToElement: true,
-    /*
-     * Should we scroll the tooltip or target element?
-     *
-     * Options are: 'element' or 'tooltip'
-     */
-    scrollTo: "element",
-    /* Padding to add after scrolling when element is not in the viewport (in pixels) */
-    scrollPadding: 30,
-    /* Set the overlay opacity */
-    overlayOpacity: 0.5,
-    /* Precedence of positions, when auto is enabled */
-    positionPrecedence: ["bottom", "top", "right", "left"],
-    /* Disable an interaction with element? */
-    disableInteraction: false,
-    /* Set how much padding to be used around helper element */
-    helperElementPadding: 10,
-    /* Default hint position */
-    hintPosition: "top-middle",
-    /* Hint button label */
-    hintButtonLabel: "Got it",
-    /* Adding animation to hints? */
-    hintAnimation: true,
-    /* additional classes to put on the buttons */
-    buttonClass: "introjs-button",
-    /* additional classes to put on progress bar */
-    progressBarAdditionalClass: false,
-  };
-}
-
 const introJs = (targetElm) => {
+  /** @type IntroJs */
   let instance;
 
   if (typeof targetElm === "object") {
@@ -137,7 +71,7 @@ introJs.version = version;
  */
 introJs.instances = {};
 
-//Prototype
+// Prototype
 introJs.fn = IntroJs.prototype = {
   clone() {
     return new IntroJs(this);
@@ -315,5 +249,8 @@ introJs.fn = IntroJs.prototype = {
     return this;
   },
 };
+
+// extends introjs to accept .on/.off event methods
+Object.assign(IntroJs.prototype, events);
 
 export default introJs;


### PR DESCRIPTION
Add events to deal with circular dependencies; added some type annotations and definitions; cleaned up some methods.

Also, events could make for a nicer/more flexible API, going forward.

Think of this line:

```js
  // signal to all listeners that introjs has exited
  this.fire('exit');

  // check if any callback is defined
  if (this._introExitCallback !== undefined) {
    this._introExitCallback.call(this);
  }
```

Devs can add all the introJs.on('exit') handlers they want.