### PR TITLE
Fix exit on Esc in IE11

### DIFF
--- a/src/core/onKeyDown.js
+++ b/src/core/onKeyDown.js
@@ -20,9 +20,9 @@ import exitIntro from "./exitIntro";
  * @return type
  */
 export default function onKeyDown(e) {
-  let code = e.code === null ? e.which : e.code;
+  let code = e.code === undefined ? e.which : e.code;
 
-  // if code/e.which is null
+  // if e.which is null
   if (code === null) {
     code = e.charCode === null ? e.keyCode : e.charCode;
   }


### PR DESCRIPTION
# Description
`e.code` can't be `null`. It's `undefined` in IE11 (missing property).

# How to reproduce
1. Open https://introjs.com/ in IE11.
2. Click on Live demo button.
3. Press Esc.