### PR TITLE
Fixes issue #1147: Positioning breaks when passing relatively-positioned element to introJs()

### DIFF
--- a/src/core/setHelperLayerPosition.js
+++ b/src/core/setHelperLayerPosition.js
@@ -17,7 +17,7 @@ export default function setHelperLayerPosition(helperLayer) {
     if (!this._introItems[this._currentStep]) return;
 
     const currentElement = this._introItems[this._currentStep];
-    const elementPosition = getOffset(currentElement.element);
+    const elementPosition = getOffset(currentElement.element, this._targetElement);
     let widthHeightPadding = this._options.helperElementPadding;
 
     // If the target element is fixed, the tooltip should be fixed as well.

--- a/src/util/getOffset.js
+++ b/src/util/getOffset.js
@@ -1,22 +1,25 @@
 /**
- * Get an element position on the page
+ * Get an element position on the page relative to another element (or root)
  * Thanks to `meouw`: http://stackoverflow.com/a/442474/375966
  *
  * @api private
  * @method _getOffset
  * @param {Object} element
+ * @param {Object} relativeEl
  * @returns Element's position info
  */
-export default function getOffset(element) {
+export default function getOffset(element, relativeEl) {
   const body = document.body;
   const docEl = document.documentElement;
   const scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop;
   const scrollLeft = window.pageXOffset || docEl.scrollLeft || body.scrollLeft;
+  relativeEl = relativeEl || body;
   const x = element.getBoundingClientRect();
+  const xr = relativeEl.getBoundingClientRect();
   return {
-    top: x.top + scrollTop,
+    top: x.top + scrollTop - xr.top,
     width: x.width,
     height: x.height,
-    left: x.left + scrollLeft,
+    left: x.left + scrollLeft - xr.left,
   };
 }


### PR DESCRIPTION
This fixes issue #1147. The solution here is to subtract the top/left values of `this._targetElement` from the calculated position.