### PR TITLE
chore: update build file to create 2 versions (es5 and raw one)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "https://github.com/usablica/intro.js"
   },
-  "main": "intro.js",
+  "main": "intro.es5.js",
   "scripts": {
     "prettier": "prettier --write 'src/**/*'",
     "test": "npm run test:jest && npm run test:jshint",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,9 +33,6 @@ const jsPlugins = [
   filesize({
     showGzippedSize: true,
   }),
-  babel({
-    exclude: 'node_modules/**'
-  }),
   commonjs()
 ];
 
@@ -108,7 +105,7 @@ export default [
   {
     input: `${inputPath}/index.js`,
     output: {
-      file: `${outputPath}/${pkg.main}`,
+      file: `${outputPath}/${pkg.main.replace(/\.es5.js$/, '.js')}`,
       format: 'umd',
       banner,
       name: 'introJs'
@@ -118,13 +115,44 @@ export default [
   {
     input: `${inputPath}/index.js`,
     output: {
-      file: `${outputPath}/minified/${pkg.main.replace(/\.js$/, '.min.js')}`,
+      file: `${outputPath}/${pkg.main}`,
+      format: 'umd',
+      banner,
+      name: 'introJs'
+    },
+    plugins: [
+      ...jsPlugins,
+      babel({
+        exclude: 'node_modules/**'
+      })
+    ]
+  },
+  {
+    input: `${inputPath}/index.js`,
+    output: {
+      file: `${outputPath}/minified/${pkg.main.replace(/\.es5.js$/, '.js')}`,
       banner,
       format: 'umd',
       name: 'introJs'
     },
     plugins: [
       ...jsPlugins,
+      terser()
+    ]
+  },
+  {
+    input: `${inputPath}/index.js`,
+    output: {
+      file: `${outputPath}/minified/${pkg.main}`,
+      banner,
+      format: 'umd',
+      name: 'introJs'
+    },
+    plugins: [
+      ...jsPlugins,
+      babel({
+        exclude: 'node_modules/**'
+      }),
       terser()
     ]
   }


### PR DESCRIPTION
Not everyone wants to use default babelified version of the package due to multiple reasons:
- modern browser support
- willingness to use smaller version of the file (in this case twice smaller than original one)
- existence of potential conflict with already embedded core-js library on the page

So I decided to push some change that will be still compatible with current version (as main file in package.json has been changed too). If someone wants to use raw code wirtten in UMD style I believe it can be truly beneficial for wider audience.

Let me know what do you think.
The code itself it is not super sophisticated, it just the matter of rollup configuration.