### PR TITLE
fix bug (checkRight)

### DIFF
--- a/src/util/checkRight.js
+++ b/src/util/checkRight.js
@@ -11,7 +11,7 @@ export default function checkRight(
   tooltipLayer
 ) {
   if (
-    targetOffset.left + tooltipLayerStyleLeft + tooltipOffset.width >
+    targetOffset.style.left + tooltipLayerStyleLeft + tooltipOffset.width >
     windowSize.width
   ) {
     // off the right side of the window


### PR DESCRIPTION
When the "tooltipPosition" is set to "right", the configuration not in effect.

So I modified the "checkRight.js" file