### PR TITLE
Allows for local step asynchronous events

### DIFF
--- a/src/core/introForElement.js
+++ b/src/core/introForElement.js
@@ -135,7 +135,7 @@ export default function introForElement (targetElm, group) {
             element: currentElement,
             title: currentElement.getAttribute("data-title") || "",
             intro: currentElement.getAttribute("data-intro"),
-            step: parseInt(currentElement.getAttribute("data-step"), 10),
+            step,
             tooltipClass: currentElement.getAttribute("data-tooltipclass"),
             highlightClass: currentElement.getAttribute("data-highlightclass"),
             position:

--- a/src/core/showElement.js
+++ b/src/core/showElement.js
@@ -55,8 +55,10 @@ function _disableInteraction() {
  * @method _showElement
  * @param {Object} targetElement
  */
-export default function _showElement(targetElement) {
-  if (typeof this._introChangeCallback !== "undefined") {
+export default function _showElement (targetElement) {
+  if (typeof targetElement.onchange === 'function') {
+    targetElement.onchange();
+  } else if (typeof this._introChangeCallback !== "undefined") {
     this._introChangeCallback.call(this, targetElement.element);
   }
 
@@ -69,7 +71,6 @@ export default function _showElement(targetElement) {
   let nextTooltipButton;
   let prevTooltipButton;
   let skipTooltipButton;
-  let scrollParent;
 
   //check for a current step highlight class
   if (typeof targetElement.highlightClass === "string") {
@@ -356,7 +357,9 @@ export default function _showElement(targetElement) {
         self._introCompleteCallback.call(self);
       }
 
-      if (typeof self._introSkipCallback === "function") {
+      if (typeof targetElement.onskip === 'function') {
+        targetElement.onskip.call(self);
+      } else if (typeof self._introSkipCallback === "function") {
         self._introSkipCallback.call(self);
       }
 
@@ -503,7 +506,9 @@ export default function _showElement(targetElement) {
 
   setShowElement(targetElement);
 
-  if (typeof this._introAfterChangeCallback !== "undefined") {
+  if (typeof targetElement.onafterchange === 'function') {
+    targetElement.onafterchange();
+  } else if (typeof this._introAfterChangeCallback !== "undefined") {
     this._introAfterChangeCallback.call(this, targetElement.element);
   }
 }

--- a/src/core/showElement.js
+++ b/src/core/showElement.js
@@ -55,7 +55,7 @@ function _disableInteraction() {
  * @method _showElement
  * @param {Object} targetElement
  */
-export default function _showElement (targetElement) {
+export default function _showElement(targetElement) {
   if (typeof targetElement.onchange === 'function') {
     targetElement.onchange();
   } else if (typeof this._introChangeCallback !== "undefined") {
@@ -95,6 +95,22 @@ export default function _showElement (targetElement) {
     const oldtooltipContainer = oldReferenceLayer.querySelector(
       ".introjs-tooltip"
     );
+    const oldTooltipHeaderLayer = oldReferenceLayer.querySelector(
+      ".introjs-tooltip-header"
+    );
+
+    // remove previous step class
+    oldReferenceLayer.classList.remove(`step-${targetElement.step - 1}`);
+    // remove next step class in case going back
+    oldReferenceLayer.classList.remove(`step-${targetElement.step + 1}`);
+    // add current step class
+    oldReferenceLayer.classList.add(`step-${targetElement.step}`);
+
+    if (targetElement.title) {
+      oldTooltipHeaderLayer.classList.remove('no-title');
+    } else {
+      oldTooltipHeaderLayer.classList.add('no-title');
+    }
 
     skipTooltipButton = oldReferenceLayer.querySelector(".introjs-skipbutton");
     prevTooltipButton = oldReferenceLayer.querySelector(".introjs-prevbutton");
@@ -192,7 +208,7 @@ export default function _showElement (targetElement) {
       className: highlightClass,
     });
     const referenceLayer = createElement("div", {
-      className: "introjs-tooltipReferenceLayer",
+      className: `introjs-tooltipReferenceLayer step-${targetElement.step}`,
     });
     const arrowLayer = createElement("div", {
       className: "introjs-arrow",
@@ -232,6 +248,10 @@ export default function _showElement (targetElement) {
 
     tooltipTextLayer.innerHTML = targetElement.intro;
     tooltipTitleLayer.innerHTML = targetElement.title;
+
+    if (!targetElement.title) {
+      tooltipHeaderLayer.classList.add('no-title');
+    }
 
     if (this._options.showBullets === false) {
       bulletsLayer.style.display = "none";

--- a/src/core/steps.js
+++ b/src/core/steps.js
@@ -67,6 +67,7 @@ export function nextStep () {
       if (typeof this._introCompleteCallback === "function") {
         this._introCompleteCallback.call(this);
       }
+
       exitIntro.call(this, this._targetElement);
       return;
     }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -211,4 +211,129 @@ describe("intro", () => {
     expect(fixed.className).toContain("introjs-showElement");
     expect(fixed.className).not.toContain("introjs-relativePosition");
   });
+
+  test("should only add appropriate step classes on steps", () => {
+    const ijs = introJs()
+      .setOptions({
+        steps: [
+          {
+            intro: "step one",
+          },
+          {
+            intro: "step two",
+          }
+        ],
+      })
+      .start();
+
+    expect(className(".introjs-tooltipReferenceLayer")).toContain(
+      "step-1"
+    );
+
+    ijs.nextStep();
+
+    expect(className(".introjs-tooltipReferenceLayer")).toContain(
+      "step-2"
+    );
+  });
+
+  test("should add/remove no-title class on appropriate steps", () => {
+    const ijs = introJs()
+      .setOptions({
+        steps: [
+          {
+            intro: "step one",
+          },
+          {
+            title: "test title",
+            intro: "step two",
+          },
+          {
+            intro: "step three"
+          }
+        ],
+      })
+      .start();
+
+    expect(className(".introjs-tooltip-header")).toContain(
+      "no-title"
+    );
+
+    ijs.nextStep();
+
+    expect(className(".introjs-tooltip-header")).not.toContain(
+      "no-title"
+    );
+
+    ijs.nextStep();
+
+    expect(className(".introjs-tooltip-header")).toContain(
+      "no-title"
+    );
+  });
+
+  test("should call local step events instead of global when available", () => {
+    let calledLocalOnBeforeChange = false;
+    let calledLocalOnChange = false;
+    let calledGlobalOnBeforeChange = false;
+    let calledGlobalOnChange = false;
+
+    const ijs = introJs()
+      .setOptions({
+        steps: [
+          {
+            intro: "step one",
+          },
+          {
+            intro: "step two",
+            onbeforechange (next) {
+              calledLocalOnBeforeChange = true;
+
+              next();
+            },
+            onchange () {
+              calledLocalOnChange = true;
+            }
+          },
+          {
+            intro: "step three"
+          }
+        ],
+      })
+      .onbeforechange(() => {
+        calledGlobalOnBeforeChange = true;
+      })
+      .onchange(() => {
+        calledGlobalOnChange = true;
+      })
+      .start();
+
+    expect(calledLocalOnBeforeChange).toBe(false);
+    expect(calledLocalOnBeforeChange).toBe(false);
+    expect(calledGlobalOnBeforeChange).toBe(true);
+    expect(calledGlobalOnChange).toBe(true);
+
+    calledGlobalOnBeforeChange = false;
+    calledGlobalOnChange = false;
+
+    ijs.nextStep();
+
+    expect(calledLocalOnBeforeChange).toBe(true);
+    expect(calledLocalOnBeforeChange).toBe(true);
+    expect(calledGlobalOnBeforeChange).toBe(false);
+    expect(calledGlobalOnChange).toBe(false);
+
+    calledLocalOnBeforeChange = false;
+    calledLocalOnChange = false;
+
+    ijs.nextStep();
+
+    expect(calledLocalOnBeforeChange).toBe(false);
+    expect(calledLocalOnBeforeChange).toBe(false);
+    expect(calledGlobalOnBeforeChange).toBe(true);
+    expect(calledGlobalOnChange).toBe(true);
+
+    calledGlobalOnBeforeChange = false;
+    calledGlobalOnChange = false;
+  });
 });


### PR DESCRIPTION
- Individual steps can now provide `onbeforechange(next)` and `onchange()` event callbacks
- When provided, the local events would be called while the global events would not.

Bonus:

- Adds class `no-title` to the tooltip header layer if a step doesn't have a title
- Adds step class (step-[STEP_NUMBER]) to the reference layer