### PR TITLE
(Fix) On resize method throws error when IntroJS is not visible on the page

### DIFF
--- a/src/core/onResize.js
+++ b/src/core/onResize.js
@@ -1,5 +1,7 @@
 import refresh from "./refresh";
 
 export default function onResize() {
-  refresh.call(this);
+  if (document.querySelector('.introjs-tooltip') !== null) {
+    refresh.call(this);
+  }
 }


### PR DESCRIPTION
This fixes Issue #861