### PR TITLE
#791

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,5 @@
 {
-  "esversion": 6,
+  "esversion": 8,
   "undef": true,
   "unused": true,
   "eqeqeq": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2198,150 +2198,6 @@
         }
       }
     },
-    "@jest/transform": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.0.2.tgz",
-      "integrity": "sha512-H8sqKlgtDfVog/s9I4GG2XMbi4Ar7RBxjsKQDUhn2XHAi3NG+GoQwWMER+YfantzExbjNqQvqBHzo/G2pfTiPw==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "^7.1.0",
-        "@jest/types": "^27.0.2",
-        "babel-plugin-istanbul": "^6.0.0",
-        "chalk": "^4.0.0",
-        "convert-source-map": "^1.4.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.2",
-        "jest-regex-util": "^27.0.1",
-        "jest-util": "^27.0.2",
-        "micromatch": "^4.0.4",
-        "pirates": "^4.0.1",
-        "slash": "^3.0.0",
-        "source-map": "^0.6.1",
-        "write-file-atomic": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "@jest/types": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-      "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
-      "dev": true,
-      "requires": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^16.0.0",
-        "chalk": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "@npmcli/git": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-2.0.9.tgz",
@@ -7662,55 +7518,6 @@
       "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
       "dev": true
     },
-    "jest-haste-map": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.0.2.tgz",
-      "integrity": "sha512-37gYfrYjjhEfk37C4bCMWAC0oPBxDpG0qpl8lYg8BT//wf353YT/fzgA7+Dq0EtM7rPFS3JEcMsxdtDwNMi2cA==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^27.0.2",
-        "@types/graceful-fs": "^4.1.2",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "fsevents": "^2.3.2",
-        "graceful-fs": "^4.2.4",
-        "jest-regex-util": "^27.0.1",
-        "jest-serializer": "^27.0.1",
-        "jest-util": "^27.0.2",
-        "jest-worker": "^27.0.2",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.7"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "jest-worker": {
-          "version": "27.0.2",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.2.tgz",
-          "integrity": "sha512-EoBdilOTTyOgmHXtw/cPc+ZrCA0KJMrkXzkrPGNwLmnvvlN1nj7MPrxpT7m+otSv2e1TLaVffzDnE/LB14zJMg==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*",
-            "merge-stream": "^2.0.0",
-            "supports-color": "^8.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "jest-jasmine2": {
       "version": "27.0.6",
       "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.0.6.tgz",
@@ -8047,12 +7854,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
-    },
-    "jest-regex-util": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.1.tgz",
-      "integrity": "sha512-6nY6QVcpTgEKQy1L41P4pr3aOddneK17kn3HJw6SdwGiKfgCGTvH02hVXL0GU8GEKtPH83eD2DIDgxHXOxVohQ==",
       "dev": true
     },
     "jest-resolve": {
@@ -8627,16 +8428,6 @@
         }
       }
     },
-    "jest-serializer": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.0.1.tgz",
-      "integrity": "sha512-svy//5IH6bfQvAbkAEg1s7xhhgHTtXu0li0I2fdKHDsLP2P2MOiscPQIENQep8oU2g2B3jqLyxKKzotZOz4CwQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "graceful-fs": "^4.2.4"
-      }
-    },
     "jest-snapshot": {
       "version": "27.0.6",
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.0.6.tgz",
@@ -8856,71 +8647,6 @@
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
-        }
-      }
-    },
-    "jest-util": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.0.2.tgz",
-      "integrity": "sha512-1d9uH3a00OFGGWSibpNYr+jojZ6AckOMCXV2Z4K3YXDnzpkAaXQyIpY14FOJPiUmil7CD+A6Qs+lnnh6ctRbIA==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^27.0.2",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.4",
-        "is-ci": "^3.0.0",
-        "picomatch": "^2.2.3"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },

--- a/src/core/exitIntro.js
+++ b/src/core/exitIntro.js
@@ -13,14 +13,14 @@ import removeChild from "../util/removeChild";
  * @param {Object} targetElement
  * @param {Boolean} force - Setting to `true` will skip the result of beforeExit callback
  */
-export default function exitIntro(targetElement, force) {
+export default async function exitIntro(targetElement, force) {
   let continueExit = true;
 
   // calling onbeforeexit callback
   //
   // If this callback return `false`, it would halt the process
   if (this._introBeforeExitCallback !== undefined) {
-    continueExit = this._introBeforeExitCallback.call(this);
+    continueExit = await this._introBeforeExitCallback.call(this);
   }
 
   // skip this check if `force` parameter is `true`
@@ -61,7 +61,7 @@ export default function exitIntro(targetElement, force) {
 
   //check if any callback is defined
   if (this._introExitCallback !== undefined) {
-    this._introExitCallback.call(this);
+    await this._introExitCallback.call(this);
   }
 
   //set the step to zero

--- a/src/core/hint.js
+++ b/src/core/hint.js
@@ -27,7 +27,7 @@ export function hintQuerySelectorAll(selector) {
  * @api private
  * @method hideHint
  */
-export function hideHint(stepId) {
+export async function hideHint(stepId) {
   const hint = hintQuerySelectorAll(`.introjs-hint[data-step="${stepId}"]`)[0];
 
   removeHintTooltip.call(this);
@@ -38,7 +38,7 @@ export function hideHint(stepId) {
 
   // call the callback function (if any)
   if (typeof this._hintCloseCallback !== "undefined") {
-    this._hintCloseCallback.call(this, stepId);
+    await this._hintCloseCallback.call(this, stepId);
   }
 }
 
@@ -125,7 +125,7 @@ export function removeHint(stepId) {
  * @api private
  * @method addHints
  */
-export function addHints() {
+export async function addHints() {
   const self = this;
 
   let hintsWrapper = document.querySelector(".introjs-hints");
@@ -206,7 +206,7 @@ export function addHints() {
 
   // call the callback function (if any)
   if (typeof this._hintsAddedCallback !== "undefined") {
-    this._hintsAddedCallback.call(this);
+    await this._hintsAddedCallback.call(this);
   }
 }
 
@@ -274,7 +274,7 @@ export function alignHintPosition(position, { style }, element) {
  * @method _showHintDialog
  * @param {Number} stepId
  */
-export function showHintDialog(stepId) {
+export async function showHintDialog(stepId) {
   const hintElement = document.querySelector(
     `.introjs-hint[data-step="${stepId}"]`
   );
@@ -282,7 +282,7 @@ export function showHintDialog(stepId) {
 
   // call the callback function (if any)
   if (typeof this._hintClickCallback !== "undefined") {
-    this._hintClickCallback.call(this, hintElement, item, stepId);
+    await this._hintClickCallback.call(this, hintElement, item, stepId);
   }
 
   // remove all open tooltips

--- a/src/core/onKeyDown.js
+++ b/src/core/onKeyDown.js
@@ -19,7 +19,7 @@ import exitIntro from "./exitIntro";
  * @param type var
  * @return type
  */
-export default function onKeyDown(e) {
+export default async function onKeyDown(e) {
   let code = e.code === undefined ? e.which : e.code;
 
   // if e.which is null
@@ -49,7 +49,7 @@ export default function onKeyDown(e) {
         this._introItems.length - 1 === this._currentStep &&
         typeof this._introCompleteCallback === "function"
       ) {
-        this._introCompleteCallback.call(this);
+        await this._introCompleteCallback.call(this);
       }
 
       exitIntro.call(this, this._targetElement);

--- a/src/core/showElement.js
+++ b/src/core/showElement.js
@@ -185,9 +185,9 @@ export function _updateProgressBar(oldReferenceLayer) {
  * @method _showElement
  * @param {Object} targetElement
  */
-export default function _showElement(targetElement) {
+export default async function _showElement(targetElement) {
   if (typeof this._introChangeCallback !== "undefined") {
-    this._introChangeCallback.call(this, targetElement.element);
+    await this._introChangeCallback.call(this, targetElement.element);
   }
 
   const self = this;
@@ -372,12 +372,12 @@ export default function _showElement(targetElement) {
     //next button
     nextTooltipButton = createElement("a");
 
-    nextTooltipButton.onclick = () => {
+    nextTooltipButton.onclick = async () => {
       if (self._introItems.length - 1 !== self._currentStep) {
         nextStep.call(self);
       } else if (/introjs-donebutton/gi.test(nextTooltipButton.className)) {
         if (typeof self._introCompleteCallback === "function") {
-          self._introCompleteCallback.call(self);
+          await self._introCompleteCallback.call(self);
         }
 
         exitIntro.call(self, self._targetElement);
@@ -407,16 +407,16 @@ export default function _showElement(targetElement) {
     setAnchorAsButton(skipTooltipButton);
     skipTooltipButton.innerHTML = this._options.skipLabel;
 
-    skipTooltipButton.onclick = () => {
+    skipTooltipButton.onclick = async () => {
       if (
         self._introItems.length - 1 === self._currentStep &&
         typeof self._introCompleteCallback === "function"
       ) {
-        self._introCompleteCallback.call(self);
+        await self._introCompleteCallback.call(self);
       }
 
       if (typeof self._introSkipCallback === "function") {
-        self._introSkipCallback.call(self);
+        await self._introSkipCallback.call(self);
       }
 
       exitIntro.call(self, self._targetElement);
@@ -563,6 +563,6 @@ export default function _showElement(targetElement) {
   setShowElement(targetElement);
 
   if (typeof this._introAfterChangeCallback !== "undefined") {
-    this._introAfterChangeCallback.call(this, targetElement.element);
+    await this._introAfterChangeCallback.call(this, targetElement.element);
   }
 }

--- a/src/core/steps.js
+++ b/src/core/steps.js
@@ -35,7 +35,7 @@ export function goToStepNumber(step) {
  * @api private
  * @method _nextStep
  */
-export function nextStep() {
+export async function nextStep() {
   this._direction = "forward";
 
   if (typeof this._currentStepNumber !== "undefined") {
@@ -57,7 +57,7 @@ export function nextStep() {
   let continueStep = true;
 
   if (typeof this._introBeforeChangeCallback !== "undefined") {
-    continueStep = this._introBeforeChangeCallback.call(
+    continueStep = await this._introBeforeChangeCallback.call(
       this,
       nextStep && nextStep.element
     );
@@ -73,7 +73,7 @@ export function nextStep() {
     //end of the intro
     //check if any callback is defined
     if (typeof this._introCompleteCallback === "function") {
-      this._introCompleteCallback.call(this);
+      await this._introCompleteCallback.call(this);
     }
     exitIntro.call(this, this._targetElement);
     return;
@@ -88,7 +88,7 @@ export function nextStep() {
  * @api private
  * @method _previousStep
  */
-export function previousStep() {
+export async function previousStep() {
   this._direction = "backward";
 
   if (this._currentStep === 0) {
@@ -101,7 +101,7 @@ export function previousStep() {
   let continueStep = true;
 
   if (typeof this._introBeforeChangeCallback !== "undefined") {
-    continueStep = this._introBeforeChangeCallback.call(
+    continueStep = await this._introBeforeChangeCallback.call(
       this,
       nextStep && nextStep.element
     );

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -40,7 +40,7 @@ describe("intro", () => {
     );
   });
 
-  test("should call onexit and oncomplete when there is one step", () => {
+  test("should call onexit and oncomplete when there is one step", async () => {
     const onexitMock = jest.fn();
     const oncompleteMMock = jest.fn();
 
@@ -56,13 +56,13 @@ describe("intro", () => {
       .oncomplete(oncompleteMMock)
       .start();
 
-    nextButton().click();
+    await nextButton().click();
 
     expect(onexitMock).toBeCalledTimes(1);
     expect(oncompleteMMock).toBeCalledTimes(1);
   });
 
-  test("should call onexit when skip is clicked", () => {
+  test("should call onexit when skip is clicked", async () => {
     const onexitMock = jest.fn();
     const oncompleteMMock = jest.fn();
 
@@ -78,7 +78,7 @@ describe("intro", () => {
       .oncomplete(oncompleteMMock)
       .start();
 
-    skipButton().click();
+    await skipButton().click();
 
     expect(onexitMock).toBeCalledTimes(1);
     expect(oncompleteMMock).toBeCalledTimes(1);

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,4 +1,5 @@
 import { JSDOM } from "jsdom";
+import 'regenerator-runtime/runtime';
 
 const dom = new JSDOM();
 global.document = dom.window.document;


### PR DESCRIPTION
* Added await syntax to all callbacks


This is how the code has been implemented in our system, allowing us to open modals and wait until they are done loading.
I'm currently loading our fork. But would be nice if you guys could test it further and eventually create it as a version.

```
this.introJs.onbeforechange(async () => await this.stepChange());


public async stepChange(): Promise<void> {
	const currentStepIndex: number = this.introJs._currentStep;

	if (this.currentStepIndex && 'function' === typeof this.steps[this.currentStepIndex]?.onLeave) {
		await this.steps[this.currentStepIndex]?.onLeave();
	}

	if (!this.steps[currentStepIndex]) {
		return;
	}

	if ('function' === typeof this.steps[currentStepIndex]?.onEnter) {
		await this.steps[currentStepIndex]?.onEnter();
	}

	this.currentStepIndex = currentStepIndex;
}

onEnter: () => {
	return new Promise((resolve: () => void) => {
		const subscription: Subscription = this.campaignModalService.bsModalService.onShown
			.subscribe(() => {
				resolve();
				subscription.unsubscribe();
			});
		this.campaignModalService.show(TourComponent.TOUR_CAMPAIGN_ID);
	});
}
```