### PR TITLE
prevent errors on refresh

### DIFF
--- a/src/core/refresh.js
+++ b/src/core/refresh.js
@@ -38,6 +38,18 @@ export default function refresh(refreshSteps) {
     const oldArrowLayer = document.querySelector(".introjs-arrow");
     const oldtooltipContainer = document.querySelector(".introjs-tooltip");
 
+    if (!this._introItems[this._currentStep].element) {
+      return;
+    }
+
+    if (!oldtooltipContainer) {
+      return;
+    }
+
+    if (!oldArrowLayer) {
+      return;
+    }
+
     placeTooltip.call(
       this,
       this._introItems[this._currentStep].element,


### PR DESCRIPTION
This responds to the suggestion in @nicobarengo 's PR (https://github.com/usablica/intro.js/pull/1330), and covers additional error cases. Two cases have documented issues: when no element matches `.introjs-tooltip` and when the `element` property is null. Both of these issues cause `placeTooltip` to throw. 

Related: 
- https://github.com/usablica/intro.js/issues/861
- https://github.com/HiDeoo/intro.js-react/issues/70
- https://github.com/usablica/intro.js/issues/1282