### PR TITLE
Improve readability of release history docs page

### DIFF
--- a/docs/docs/developers/release-history.md
+++ b/docs/docs/developers/release-history.md
@@ -6,4 +6,4 @@ categories: developers
 permalink: /developers/changelog/
 ---
 
-On <a href="https://github.com/usablica/intro.js/blob/master/changelog.md">Release History</a> page you can find a complete list of releases history.
+On the <a href="https://github.com/usablica/intro.js/blob/master/changelog.md">Release History</a> page you can find a complete list of releases.


### PR DESCRIPTION
Add missing article and remove redundant "history" at the end of the sentence.