### PR TITLE
fix: typo in introjs.scss

### DIFF
--- a/src/styles/introjs.scss
+++ b/src/styles/introjs.scss
@@ -232,7 +232,7 @@ tr.introjs-showElement {
   background-color: $black100;
   border-radius: 0.2em;
   zoom: 1;
-  *display: inline;
+  display: inline;
 
   &:hover {
     outline: none;


### PR DESCRIPTION
the typo shows up as a warning when building the project
fixes [the issue reported here](https://github.com/usablica/intro.js/issues/1507)