### PR TITLE
Add next/previous callbacks

### DIFF
--- a/example/callbacks/onnext-onprev.html
+++ b/example/callbacks/onnext-onprev.html
@@ -73,11 +73,11 @@
         var intro = introJs();
         intro.onnext(function () {
           const nextStep = this.currentStep() + 1;
-          alert(`Next up: ${this._introItems[nextStep].intro}`);
+          return confirm(`Next intro: ${this._introItems[nextStep].intro}\nProceed?`);
         });
         intro.onprevious(function () {
           const nextStep = this.currentStep() - 1;
-          alert(`Next up: ${this._introItems[nextStep].intro}`);
+          return confirm(`Previous intro: ${this._introItems[nextStep].intro}\nProceed?`);
         });
         intro.start();
       }

--- a/example/callbacks/onnext-onprev.html
+++ b/example/callbacks/onnext-onprev.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Callbacks: onnext & onprev</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Intro.js - Better introductions for websites and features with a step-by-step guide for your projects.">
+    <meta name="author" content="Afshin Mehrabani (@afshinmeh) in usabli.ca group">
+
+    <!-- styles -->
+    <link href="../assets/css/bootstrap.min.css" rel="stylesheet"> <link href="../assets/css/demo.css" rel="stylesheet">
+
+    <!-- Add IntroJs styles -->
+    <link href="../../dist/introjs.css" rel="stylesheet">
+
+    <link href="../assets/css/bootstrap-responsive.min.css" rel="stylesheet">
+  </head>
+
+  <body>
+
+    <div class="container-narrow">
+
+      <div class="masthead">
+        <ul class="nav nav-pills pull-right" data-step="5" data-intro="Get it, use it.">
+          <li><a href="https://github.com/usablica/intro.js/tags"><i class='icon-black icon-download-alt'></i> Download</a></li>
+          <li><a href="https://github.com/usablica/intro.js">Github</a></li>
+          <li><a href="https://twitter.com/usablica">@usablica</a></li>
+        </ul>
+        <h3 class="muted">Intro.js</h3>
+      </div>
+
+      <hr>
+
+      <div class="jumbotron">
+        <h1 data-step="1" data-intro="This is a tooltip!">Usage of onnext & onprev</h1>
+        <p class="lead" data-step="4" data-intro="Another step.">In this example you learn how to use <code>onnext & onprev</code> callback to prevent displaying a step.</p>
+        <a class="btn btn-large btn-success" href="javascript:void(0);" onclick="javascript:startIntro();">Show me how</a>
+      </div>
+
+      <hr>
+
+      <div class="row-fluid marketing">
+        <div class="span6" data-step="2" data-intro="Ok, wasn't that fun?" data-position='right' data-scrollto='tooltip'>
+          <h4>Section One</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+          <h4>Section Two</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+          <h4>Section Three</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+          </div>
+
+        <div class="span6" data-step="3" data-intro="More features, more fun."  data-position='left'>
+          <h4>Section Four</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+          <h4>Section Five</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+          <h4>Section Six</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+        </div>
+      </div>
+
+      <hr>
+    </div>
+    <script type="text/javascript" src="../../dist/intro.js"></script>
+
+    <script type="text/javascript">
+      function startIntro(){
+        var intro = introJs();
+        intro.onnext(function () {
+          const nextStep = this.currentStep() + 1;
+          alert(`Next up: ${this._introItems[nextStep].intro}`);
+        });
+        intro.onprevious(function () {
+          const nextStep = this.currentStep() - 1;
+          alert(`Next up: ${this._introItems[nextStep].intro}`);
+        });
+        intro.start();
+      }
+    </script>
+  </body>
+</html>

--- a/src/core/steps.js
+++ b/src/core/steps.js
@@ -103,10 +103,18 @@ export function previousStep() {
     return false;
   }
 
-  --this._currentStep;
 
-  const nextStep = this._introItems[this._currentStep];
+  const nextStep = this._introItems[this._currentStep - 1];
   let continueStep = true;
+
+  if (typeof this._introPreviousCallback !== "undefined") {
+    continueStep = this._introPreviousCallback.call(
+      this,
+      nextStep && nextStep.element
+    );
+  }
+
+  --this._currentStep;
 
   if (typeof this._introBeforeChangeCallback !== "undefined") {
     continueStep = this._introBeforeChangeCallback.call(

--- a/src/core/steps.js
+++ b/src/core/steps.js
@@ -56,10 +56,10 @@ export function nextStep() {
   } else {
     nextStep = this._introItems[this._currentStep + 1];
     if (typeof this._introNextCallback !== "undefined") {
-      continueStep = this._introNextCallback.call(
-        this,
-        nextStep && nextStep.element
-      );
+      continueStep = this._introNextCallback.call(this, nextStep && nextStep.element);
+      if (continueStep === false) {
+        return false;
+      }
     }
     ++this._currentStep;
   }
@@ -108,10 +108,10 @@ export function previousStep() {
   let continueStep = true;
 
   if (typeof this._introPreviousCallback !== "undefined") {
-    continueStep = this._introPreviousCallback.call(
-      this,
-      nextStep && nextStep.element
-    );
+    continueStep = this._introPreviousCallback.call(this, nextStep && nextStep.element);
+    if (continueStep === false) {
+      return false;
+    }
   }
 
   --this._currentStep;

--- a/src/core/steps.js
+++ b/src/core/steps.js
@@ -47,14 +47,22 @@ export function nextStep() {
     });
   }
 
+  let nextStep;
+  let continueStep = true;
+
   if (typeof this._currentStep === "undefined") {
     this._currentStep = 0;
+    nextStep = this._introItems[0];
   } else {
+    nextStep = this._introItems[this._currentStep + 1];
+    if (typeof this._introNextCallback !== "undefined") {
+      continueStep = this._introNextCallback.call(
+        this,
+        nextStep && nextStep.element
+      );
+    }
     ++this._currentStep;
   }
-
-  const nextStep = this._introItems[this._currentStep];
-  let continueStep = true;
 
   if (typeof this._introBeforeChangeCallback !== "undefined") {
     continueStep = this._introBeforeChangeCallback.call(

--- a/src/index.js
+++ b/src/index.js
@@ -236,6 +236,14 @@ introJs.fn = IntroJs.prototype = {
     }
     return this;
   },
+  onnext(providedCallback) {
+    if (typeof providedCallback === "function") {
+      this._introNextCallback = providedCallback;
+    } else {
+      throw new Error("Provided callback for onnext was not a function");
+    }
+    return this;
+  },
   oncomplete(providedCallback) {
     if (typeof providedCallback === "function") {
       this._introCompleteCallback = providedCallback;

--- a/src/index.js
+++ b/src/index.js
@@ -248,7 +248,7 @@ introJs.fn = IntroJs.prototype = {
     if (typeof providedCallback === "function") {
       this._introPreviousCallback = providedCallback;
     } else {
-      throw new Error("Provided callback for onnext was not a function");
+      throw new Error("Provided callback for onprevious was not a function");
     }
     return this;
   },

--- a/src/index.js
+++ b/src/index.js
@@ -244,6 +244,14 @@ introJs.fn = IntroJs.prototype = {
     }
     return this;
   },
+  onprevious(providedCallback) {
+    if (typeof providedCallback === "function") {
+      this._introPreviousCallback = providedCallback;
+    } else {
+      throw new Error("Provided callback for onnext was not a function");
+    }
+    return this;
+  },
   oncomplete(providedCallback) {
     if (typeof providedCallback === "function") {
       this._introCompleteCallback = providedCallback;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -93,6 +93,29 @@ describe("intro", () => {
     expect(onnextMock).toBeCalledTimes(1);
   });
 
+  test("should call onprevious when back is clicked", () => {
+    const onpreviousMock = jest.fn();
+
+    introJs()
+      .setOptions({
+        steps: [
+          {
+            intro: "first",
+          },
+          {
+            intro: "second",
+          },
+        ],
+      })
+      .onprevious(onpreviousMock)
+      .start();
+
+    nextButton().click();
+    prevButton().click();
+
+    expect(onpreviousMock).toBeCalledTimes(1);
+  });
+
   test("should call onexit when skip is clicked", () => {
     const onexitMock = jest.fn();
     const oncompleteMMock = jest.fn();

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -43,6 +43,7 @@ describe("intro", () => {
   test("should call onexit and oncomplete when there is one step", () => {
     const onexitMock = jest.fn();
     const oncompleteMMock = jest.fn();
+    const onnextMock = jest.fn();
 
     introJs()
       .setOptions({
@@ -54,12 +55,42 @@ describe("intro", () => {
       })
       .onexit(onexitMock)
       .oncomplete(oncompleteMMock)
+      .onnext(onnextMock)
       .start();
 
     nextButton().click();
 
     expect(onexitMock).toBeCalledTimes(1);
     expect(oncompleteMMock).toBeCalledTimes(1);
+    expect(onnextMock).toBeCalledTimes(0);
+  });
+
+  test("should call onnext when there is more than one step", () => {
+    const onexitMock = jest.fn();
+    const oncompleteMock = jest.fn();
+    const onnextMock = jest.fn();
+
+    introJs()
+      .setOptions({
+        steps: [
+          {
+            intro: "first",
+          },
+          {
+            intro: "second",
+          },
+        ],
+      })
+      .onexit(onexitMock)
+      .oncomplete(oncompleteMock)
+      .onnext(onnextMock)
+      .start();
+
+    nextButton().click();
+
+    expect(onexitMock).toBeCalledTimes(0);
+    expect(oncompleteMock).toBeCalledTimes(0);
+    expect(onnextMock).toBeCalledTimes(1);
   });
 
   test("should call onexit when skip is clicked", () => {


### PR DESCRIPTION
### What?
I've added callbacks for next and previous, including tests and an example.

### Why?
I wanted a callback that was run before the step was changed and indicated the direction of change.

onbeforechange is called after the step is changed but before it is shown (this.currentStep() returns the new step in onbeforechange) and does not tell you the direction.

Closes #1533 