### PR TITLE
Disable tour animation

### DIFF
--- a/example/disable-animation/index.html
+++ b/example/disable-animation/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Disable Tour Animation</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Intro.js - Better introductions for websites and features with a step-by-step guide for your projects.">
+    <meta name="author" content="Afshin Mehrabani (@afshinmeh) in usabli.ca group">
+
+    <!-- styles -->
+    <link href="../assets/css/bootstrap.min.css" rel="stylesheet">
+    <link href="../assets/css/demo.css" rel="stylesheet">
+
+    <!-- Add IntroJs styles -->
+    <link href="../../dist/introjs.css" rel="stylesheet">
+
+    <link href="../assets/css/bootstrap-responsive.min.css" rel="stylesheet">
+  </head>
+
+  <body>
+
+    <div class="container-narrow">
+
+      <div class="masthead">
+        <ul class="nav nav-pills pull-right" data-step="5" data-intro="Get it, use it.">
+          <li><a href="https://github.com/usablica/intro.js/tags"><i class='icon-black icon-download-alt'></i> Download</a></li>
+          <li><a href="https://github.com/usablica/intro.js">Github</a></li>
+          <li><a href="https://twitter.com/usablica">@usablica</a></li>
+        </ul>
+        <h3 class="muted">Intro.js</h3>
+      </div>
+
+      <hr>
+
+      <div class="jumbotron">
+        <h1 data-step="1" data-intro="This is a tooltip!" data-title="A short title">Disable Tour Animation</h1>
+        <p class="lead" data-step="4" data-intro="Another step." data-title="foo">This example disables the tour animation using the <code>tourAnimation</code> option.</p>
+        <a class="btn btn-large btn-success" href="javascript:void(0);" onclick="javascript:introJs().setOption('tourAnimation', false).start();">Show me how</a>
+      </div>
+
+      <hr>
+
+      <div class="row-fluid marketing">
+        <div class="span6" data-step="2" data-title="A very long title containing a lot of unnecessary text so that the title spans over multiple lines" data-intro="Ok, wasn't that fun?" data-position='right' data-scrollTo='tooltip'>
+          <h4>Section One</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+          <h4>Section Two</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+          <h4>Section Three</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+          </div>
+
+        <div class="span6" data-step="3" data-intro="More features, more fun."  data-position='left'>
+          <h4>Section Four</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+          <h4>Section Five</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+          <h4>Section Six</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+        </div>
+      </div>
+
+      <hr>
+    </div>
+    <script type="text/javascript" src="../../dist/intro.js"></script>
+  </body>
+</html>

--- a/example/index.html
+++ b/example/index.html
@@ -30,6 +30,7 @@
         <li><a href="multi-page/index.html" title='Multi-Page introduction'>Multi-Page introduction</a></li>
         <li><a href="auto-position/index.html" title='Auto-positioning'>Auto-positioning</a></li>
         <li><a href="disable-interaction/index.html" title='Disable interaction'>Disable interaction with elements</a></li>
+        <li><a href="disable-animation/index.html" title='Disable tour animation'>Disable tour animation</a></li>
         <li><a href="RTL/index.html" title='RTL version'>RTL version</a></li>
         <li><a href="html-tooltip/index.html" title='HTML in tooltip'>HTML in tooltip</a></li>
         <li><a href="custom-class/index.html" title='Custom CSS Class'>Custom CSS Class</a></li>

--- a/src/core/exitIntro.js
+++ b/src/core/exitIntro.js
@@ -4,6 +4,7 @@ import onKeyDown from "./onKeyDown";
 import onResize from "./onResize";
 import removeShowElement from "./removeShowElement";
 import removeChild from "../util/removeChild";
+import removeClass from "../util/removeClass";
 
 /**
  * Exit from intro
@@ -54,6 +55,8 @@ export default async function exitIntro(targetElement, force) {
   removeChild(floatingElement);
 
   removeShowElement();
+
+  removeClass(targetElement, "introjs-animated-tour");
 
   //clean listeners
   DOMEvent.off(window, "keydown", onKeyDown, this, true);

--- a/src/core/introForElement.js
+++ b/src/core/introForElement.js
@@ -3,6 +3,7 @@ import DOMEvent from "./DOMEvent";
 import { nextStep } from "./steps";
 import onKeyDown from "./onKeyDown";
 import onResize from "./onResize";
+import addClass from "../util/addClass";
 import fetchIntroSteps from "./fetchIntroSteps";
 
 /**
@@ -32,6 +33,10 @@ export default async function introForElement(targetElm) {
 
   //add overlay layer to the page
   if (addOverlayLayer.call(this, targetElm)) {
+    if (this._options.tourAnimation) {
+      addClass(targetElm, "introjs-animated-tour");
+    }
+
     //then, start the show
     await nextStep.call(this);
 

--- a/src/core/showElement.js
+++ b/src/core/showElement.js
@@ -246,6 +246,7 @@ export default async function _showElement(targetElement) {
     removeShowElement();
 
     //we should wait until the CSS3 transition is competed (it's 0.3 sec) to prevent incorrect `height` and `width` calculation
+    let timeout = (self._options.tourAnimation) ? 350 : 1;
     if (self._lastShowElementTimer) {
       window.clearTimeout(self._lastShowElementTimer);
     }
@@ -302,7 +303,7 @@ export default async function _showElement(targetElement) {
         targetElement,
         oldtooltipLayer
       );
-    }, 350);
+    }, timeout);
 
     // end of old element if-else condition
   } else {

--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,8 @@ function IntroJs(obj) {
     hintAutoRefreshInterval: 10,
     /* Adding animation to hints? */
     hintAnimation: true,
+    /* Whether to animate tour step transitions */
+    tourAnimation: true,
     /* additional classes to put on the buttons */
     buttonClass: "introjs-button",
     /* additional classes to put on progress bar */

--- a/src/styles/introjs.scss
+++ b/src/styles/introjs.scss
@@ -82,6 +82,8 @@ tr.introjs-showElement {
 
 // Enable introjs animations.
 .introjs-animated-tour {
+  scroll-behavior: smooth;
+
   .introjs-helperLayer {
     transition: all 0.3s ease-out;
   }

--- a/src/styles/introjs.scss
+++ b/src/styles/introjs.scss
@@ -18,7 +18,6 @@ $background_color_10: rgba(136, 136, 136, 0.24);
   box-sizing: content-box;
   z-index: 999999;
   opacity: 0;
-  transition: all 0.3s ease-out;
 }
 
 .introjs-showElement {
@@ -54,7 +53,6 @@ tr.introjs-showElement {
   position: absolute;
   z-index: 9999998;
   border-radius: 4px;
-  transition: all 0.3s ease-out;
 
   * {
     box-sizing: content-box;
@@ -76,10 +74,28 @@ tr.introjs-showElement {
   visibility: hidden;
   z-index: 100000000;
   background-color: transparent;
-  transition: all 0.3s ease-out;
 
   * {
     font-family: $font_family;
+  }
+}
+
+// Enable introjs animations.
+.introjs-animated-tour {
+  .introjs-helperLayer {
+    transition: all 0.3s ease-out;
+  }
+
+  .introjs-tooltipReferenceLayer {
+    transition: all 0.3s ease-out;
+  }
+
+  .introjs-overlay {
+    transition: all 0.3s ease-out;
+  }
+
+  .introjs-tooltip {
+    transition: opacity 0.1s ease-out;
   }
 }
 
@@ -168,7 +184,6 @@ tr.introjs-showElement {
   max-width: 300px;
   border-radius: 5px;
   box-shadow: 0 3px 30px rgba($black900, 0.3);
-  transition: opacity 0.1s ease-out;
 }
 
 .introjs-tooltiptext {

--- a/src/util/scrollTo.js
+++ b/src/util/scrollTo.js
@@ -30,21 +30,25 @@ export default function scrollTo(scrollTo, { element }, tooltipLayer) {
     // the center of the target element or tooltip.
 
     if (top < 0 || element.clientHeight > winHeight) {
-      window.scrollBy(
-        0,
-        rect.top -
+      window.scrollBy({
+        top: rect.top -
           (winHeight / 2 - rect.height / 2) -
-          this._options.scrollPadding
-      ); // 30px padding from edge to look nice
+          // 30px padding from edge to look nice
+          this._options.scrollPadding,
+        left: 0,
+        behavior: 'smooth'
+      });
 
-      //Scroll down
     } else {
-      window.scrollBy(
-        0,
-        rect.top -
+      //Scroll down
+      window.scrollBy({
+        top: rect.top -
           (winHeight / 2 - rect.height / 2) +
-          this._options.scrollPadding
-      ); // 30px padding from edge to look nice
+          // 30px padding from edge to look nice
+          this._options.scrollPadding,
+        left: 0,
+        behavior: 'smooth'
+      });
     }
   }
 }


### PR DESCRIPTION
This PR adds an option to disable any transitions of the tour (on by default). It also implements smooth page scrolling (issue #1719)