### PR TITLE
feat: add scrollElRef to support custom scroll element view

### DIFF
--- a/example/assets/css/demo.css
+++ b/example/assets/css/demo.css
@@ -5,6 +5,9 @@ body {
   font-family: 'Raleway', sans-serif;
   padding-bottom: 40px;
 }
+body.no-padding {
+  padding: 0;
+}
 
 /* Custom container */
 .container-narrow {
@@ -13,6 +16,19 @@ body {
 }
 .container-narrow > hr {
   margin: 30px 0;
+}
+.container-narrow.flex {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.header-main {
+  height: 92px;
+}
+.container-main {
+  height: calc(100vh - 92px);
+  overflow: hidden;
+  overflow-y: auto;
 }
 
 /* Main marketing message and sign up button */

--- a/example/custom-scroll-el/index.html
+++ b/example/custom-scroll-el/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>HTML in tooltip</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Intro.js - Better introductions for websites and features with a step-by-step guide for your projects.">
+    <meta name="author" content="Afshin Mehrabani (@afshinmeh) in usabli.ca group">
+
+    <!-- styles -->
+    <link href="../assets/css/bootstrap.min.css" rel="stylesheet">
+    <link href="../assets/css/demo.css" rel="stylesheet">
+
+    <!-- Add IntroJs styles -->
+    <link href="../../dist/introjs.css" rel="stylesheet">
+
+    <link href="../assets/css/bootstrap-responsive.min.css" rel="stylesheet">
+  </head>
+
+  <body class="no-padding">
+
+    <div class="container-narrow flex">
+
+      <div class="header-main">
+        <div class="masthead">
+          <ul id="step5" class="nav nav-pills pull-right">
+            <li><a href="https://github.com/usablica/intro.js/tags"><i class='icon-black icon-download-alt'></i> Download</a></li>
+            <li><a href="https://github.com/usablica/intro.js">Github</a></li>
+            <li><a href="https://twitter.com/usablica">@usablica</a></li>
+          </ul>
+          <h3 class="muted">Intro.js</h3>
+        </div>
+
+        <hr>
+      </div>
+
+      <div class="container-main" id="containerMain">
+        <div class="jumbotron">
+          <h1 id="step1">HTML in tooltip</h1>
+          <p id="step4" class="lead">We're going to use HTML codes in tooltips via Programmatic API</p>
+          <a class="btn btn-large btn-success" href="javascript:void(0);" onclick="startIntro();">Show me how</a>
+        </div>
+
+        <hr>
+
+        <div class="row-fluid marketing">
+          <div id="step2" class="span6">
+            <h4>Section One</h4>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+            <h4>Section Two</h4>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+            <h4>Section Three</h4>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+            <h4>Section Four</h4>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+            <h4>Section Five</h4>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+            <h4>Section Six</h4>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+          </div>
+
+          <div id="step3" class="span6">
+            <h4>Section Seven</h4>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+            <h4>Section Eight</h4>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+            <h4>Section Nine</h4>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+            <h4>Section Ten</h4>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+            <h4>Section Eleven</h4>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+
+            <h4 id="section-twelve">Section Twelve</h4>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis mollis augue a neque cursus ac blandit orci faucibus. Phasellus nec metus purus.</p>
+          </div>
+        </div>
+
+        <hr>
+      </div>
+    </div>
+    <script type="text/javascript" src="../../dist/intro.js"></script>
+    <script type="text/javascript">
+      function startIntro(){
+        var intro = introJs();
+          intro.setOptions({
+            steps: [
+              {
+                element: '#step1',
+                intro: "This is a <b>bold</b> tooltip."
+              },
+              {
+                element: '#section-twelve',
+                intro: "This is the section Twelve which managed by #containerMain container",
+                position: 'top'
+              },
+              {
+                element: '#step2',
+                intro: "Ok, <i>wasn't</i> that fun?",
+                position: 'right'
+              },
+              {
+                element: '#step3',
+                intro: 'More features, more <span style="color: red;">f</span><span style="color: green;">u</span><span style="color: blue;">n</span>.',
+                position: 'left'
+              },
+              {
+                element: '#step4',
+                intro: "<span style='font-family: Tahoma'>Another step with new font!</span>",
+                position: 'bottom'
+              },
+              {
+                element: '#step5',
+                intro: '<strong>Get</strong> it, <strong>use</strong> it.'
+              }
+            ]
+          });
+
+          intro.start();
+      }
+    </script>
+  </body>
+</html>
+

--- a/example/index.html
+++ b/example/index.html
@@ -33,6 +33,7 @@
         <li><a href="RTL/index.html" title='RTL version'>RTL version</a></li>
         <li><a href="html-tooltip/index.html" title='HTML in tooltip'>HTML in tooltip</a></li>
         <li><a href="custom-class/index.html" title='Custom CSS Class'>Custom CSS Class</a></li>
+        <li><a href="custom-scroll-el/index.html" title='Custom Scroll Element'>Custom Scroll Element</a></li>
         <li><a href="withoutElement/index.html" title='Introduction without focusing on elements'>Introduction without focusing on elements</a></li>
         <li><a href="bootstrap/v3/index.html" title='Using with Bootstrap v3.0'>Using with Bootstrap v3.0</a></li>
         <li><a href="svg/d3.htm" title='Using Introjs with SVG Element'>Using with SVG Elements (D3)</a></li>

--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,10 @@ function IntroJs(obj) {
      * Options are: 'element' or 'tooltip'
      */
     scrollTo: "element",
+    /**
+     * Reference Element to manage scroll
+     */
+    scrollElRef: null,
     /* Padding to add after scrolling when element is not in the viewport (in pixels) */
     scrollPadding: 30,
     /* Set the overlay opacity */

--- a/src/util/cloneObject.js
+++ b/src/util/cloneObject.js
@@ -14,10 +14,13 @@ export default function cloneObject(object) {
   const temp = {};
   for (const key in object) {
     if (
-      typeof window.jQuery !== "undefined" &&
-      object[key] instanceof window.jQuery
+      (typeof window.jQuery !== "undefined" &&
+      object[key] instanceof window.jQuery) ||
+      key === "scrollElRef"
     ) {
       temp[key] = object[key];
+    } else if (key === "window") {
+      temp[key] = window;
     } else {
       temp[key] = cloneObject(object[key]);
     }

--- a/src/util/scrollParentToElement.js
+++ b/src/util/scrollParentToElement.js
@@ -12,7 +12,9 @@ export default function scrollParentToElement(targetElement) {
 
   const parent = getScrollParent(element);
 
-  if (parent === document.body) return;
+  const scrollEl = this._introItems[this._currentStep].scrollElRef || this._options.scrollElRef || parent;
 
-  parent.scrollTop = element.offsetTop - parent.offsetTop;
+  if (scrollEl === document.body) return;
+
+  scrollEl.scrollTop = element.offsetTop - scrollEl.offsetTop;
 }

--- a/src/util/scrollTo.js
+++ b/src/util/scrollTo.js
@@ -29,8 +29,12 @@ export default function scrollTo(scrollTo, { element }, tooltipLayer) {
     // I have changed the scroll option and now it scrolls the window to
     // the center of the target element or tooltip.
 
+    const scrollEl = this._introItems[this._currentStep].scrollElRef || this._options.scrollElRef || window;
+
+    console.log(scrollEl);
+
     if (top < 0 || element.clientHeight > winHeight) {
-      window.scrollBy(
+      scrollEl.scrollBy(
         0,
         rect.top -
           (winHeight / 2 - rect.height / 2) -
@@ -39,7 +43,7 @@ export default function scrollTo(scrollTo, { element }, tooltipLayer) {
 
       //Scroll down
     } else {
-      window.scrollBy(
+      scrollEl.scrollBy(
         0,
         rect.top -
           (winHeight / 2 - rect.height / 2) +


### PR DESCRIPTION
I propose this PR in order to add options `scrollElRef` which support a custom scroll element view.

This one can be defined in global options set or in step options.

Where defined, the scroll action is defined on the element instead to be determinated by getParentScroll().

It useful typically in Ionic application where shadow container is defined and getParentScroll() not detect the scroll element. I tried to build a sample but not fully operational in Ionic-like context.
