### PR TITLE
fix: behavior of unassigned 'intro' property in json

### DIFF
--- a/src/core/fetchIntroSteps.ts
+++ b/src/core/fetchIntroSteps.ts
@@ -107,7 +107,7 @@ export default function fetchIntroSteps(
         introItems[step - 1] = {
           element: currentElement,
           title: currentElement.getAttribute("data-title") || "",
-          intro: currentElement.getAttribute("data-intro"),
+          intro: currentElement.getAttribute("data-intro") || "",
           step: parseInt(currentElement.getAttribute("data-step"), 10),
           tooltipClass: currentElement.getAttribute("data-tooltip-class"),
           highlightClass: currentElement.getAttribute("data-highlight-class"),
@@ -154,7 +154,7 @@ export default function fetchIntroSteps(
         introItems[nextStep] = {
           element: currentElement,
           title: currentElement.getAttribute("data-title") || "",
-          intro: currentElement.getAttribute("data-intro"),
+          intro: currentElement.getAttribute("data-intro") || "",
           step: nextStep + 1,
           tooltipClass: currentElement.getAttribute("data-tooltip-class"),
           highlightClass: currentElement.getAttribute("data-highlight-class"),


### PR DESCRIPTION
Currently, one has to set the `intro` property in the steps json. Changed it to behave like `title`, that is, it's not compulsory. A step could have a title only.

Without this change, a step would contain "undefined":

![image](https://github.com/usablica/intro.js/assets/5157769/cf9b5b79-cc15-49e2-ada0-62ef7f54461e)
