### PR TITLE
fix: `cloneObject` when `window.jQuery` set but null/undefined

### DIFF
--- a/src/util/cloneObject.ts
+++ b/src/util/cloneObject.ts
@@ -11,7 +11,7 @@ export default function cloneObject<T>(source: T): T {
 
   for (const key in source) {
     // @ts-ignore:next-line
-    if ("jQuery" in window && source[key] instanceof window.jQuery) {
+    if ("jQuery" in window && window.jQuery && source[key] instanceof window.jQuery) {
       temp[key] = source[key];
     } else {
       temp[key] = cloneObject(source[key]);


### PR DESCRIPTION
I encountered a problem when testing locally with `intro.js` whereby (for some reason) `window.jQuery` was set on my browser to `undefined`. This causes an exception in cloneObject as it tries to use the value for an instance of comparison.
![image](https://github.com/usablica/intro.js/assets/17804618/5faec2cc-53bd-4ac1-990f-e9c8736c55a8)

My app doesn't use jQuery, so not sure where it is coming from, but either way I think we need to assert that window.jQuery is non-nullable before continuing to the `instanceof`.

I only encountered this problem when defining the `steps` option, as `cloneObject` is used to clone the input.