### PR TITLE
fix: 🐛 ensure prev button html is updated with prevLabel option

### DIFF
--- a/src/packages/tour/showElement.ts
+++ b/src/packages/tour/showElement.ts
@@ -659,6 +659,7 @@ export default async function _showElement(tour: Tour, step: TourStep) {
           previousButtonClassName,
           disabledButtonClassName
         );
+        prevTooltipButton.innerHTML = tour.getOption("prevLabel");
       }
     }
   } else if (tour.isLastStep() || tour.getSteps().length === 1) {
@@ -711,6 +712,7 @@ export default async function _showElement(tour: Tour, step: TourStep) {
         tour.getOption("buttonClass"),
         previousButtonClassName
       );
+      prevTooltipButton.innerHTML = tour.getOption("prevLabel");
     }
     if (nextTooltipButton) {
       setClass(

--- a/src/packages/tour/showElement.ts
+++ b/src/packages/tour/showElement.ts
@@ -670,6 +670,7 @@ export default async function _showElement(tour: Tour, step: TourStep) {
         tour.getOption("buttonClass"),
         previousButtonClassName
       );
+      prevTooltipButton.innerHTML = tour.getOption("prevLabel");
     }
 
     if (tour.getOption("hideNext") === true) {


### PR DESCRIPTION
The `prev` button in was not updating its inner HTML to reflect changes made to the `prevLabel` option in the tour. 

Link to issue: https://stackblitz.com/edit/introjs-prevbutton-innerhtml?file=src%2Fmain.ts

Unlike the `next` button, which updates its label dynamically (https://github.com/usablica/intro.js/blob/master/src/packages/tour/showElement.ts#L639, https://github.com/usablica/intro.js/blob/master/src/packages/tour/showElement.ts#L689, https://github.com/usablica/intro.js/blob/master/src/packages/tour/showElement.ts#L721), the `prev` button's label was set only once when the button was created. 

This fix adds logic to update `prevTooltipButton.innerHTML` with the current `prevLabel` option in all relevant places, ensuring the label remains consistent with what is specified in the tour options.

Edit: forgot to mention the issue https://github.com/usablica/intro.js/issues/640
