### PR TITLE
fix helping layer position 

### DIFF
--- a/src/util/getOffset.ts
+++ b/src/util/getOffset.ts
@@ -30,7 +30,8 @@ export default function getOffset(
   const scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop;
   const scrollLeft = window.pageXOffset || docEl.scrollLeft || body.scrollLeft;
 
-  relativeEl = relativeEl || body;
+
+  relativeEl = relativeEl || docEl || body;
 
   const x = element.getBoundingClientRect();
   const xr = relativeEl.getBoundingClientRect();


### PR DESCRIPTION
Problem
The helping layer in Intro.js is incorrectly positioned when a Chrome extension adds a bar at the top of the page. This occurs because the additional bar alters the page's layout.

How to Recreate

Download the Chrome Extension
Use the following link to install the extension:
[Ahrefs SEO Toolbar](https://chromewebstore.google.com/detail/ahrefs-seo-toolbar-on-pag/hgmoccdbjhknikckedaaebbpdeebhiei)

Visit the Intro.js Website
Open the [Intro.js website](https://introjs.com/) and click on the Live Demo button.

Observe the Error
You will notice that the helping layer is not correctly aligned with the target element.

Error Screenshot
<img width="1680" alt="Screenshot 2025-01-10 at 2:41 PM" src="https://github.com/user-attachments/assets/afd6afe4-fc8e-449c-b598-14e7648f5ba6" />

Solution
By default, the getOffset function in Intro.js uses the <body> element as the relative element for positioning the helping layer. However, this approach is problematic when a Chrome extension modifies the <body> tag, for example, by adding a margin-top.

To resolve this issue, the function should prioritize the document.documentElement (i.e., the <html> element) over the <body> element. This ensures that the helping layer is positioned correctly, even when extensions or other scripts make layout changes to the <body> tag.

Code Adjustment:
Update the getOffset function in the Intro.js code to use document.documentElement as the default relative element.