### PR TITLE
fix: use step class name if exist in favor of a glbal (tour) classname

### DIFF
--- a/src/packages/tour/components/TourRoot.ts
+++ b/src/packages/tour/components/TourRoot.ts
@@ -128,7 +128,7 @@ export const TourRoot = ({ tour }: TourRootProps) => {
         doneLabel: tour.getOption("doneLabel"),
         hideNext: tour.getOption("hideNext"),
         hidePrev: tour.getOption("hidePrev"),
-        className: tour.getOption("tooltipClass"),
+        className: step.val.tooltipClass || tour.getOption("tooltipClass"),
         progress: tour.getOption("showProgress"),
         progressBarAdditionalClass: tour.getOption(
           "progressBarAdditionalClass"

--- a/src/packages/tour/modal.cy.ts
+++ b/src/packages/tour/modal.cy.ts
@@ -129,4 +129,27 @@ context("Modal", () => {
       });
     });
   });
+
+  it("should apply tooltipClass from step configuration over tour tooltipClass", () => {
+    cy.visit("./cypress/setup/index.html").then((win) => {
+      cy.viewport("macbook-13");
+
+      const instance = win.introJs.tour().setOptions({
+        tooltipClass: "tour-tooltip",
+        steps: [
+          {
+            element: "#main-section",
+            intro: "step tooltip class",
+            tooltipClass: "step-tooltip",
+          },
+        ],
+      });
+      instance.refresh(true);
+      instance.start();
+
+      cy.get(".introjs-tooltip")
+        .should("have.class", "step-tooltip")
+        .should("not.have.class", "tour-tooltip");
+    });
+  });
 });


### PR DESCRIPTION
### Problem
This PR addresses the tooltipClass override issue discussed in #2105. In version 8.2.0-beta.1, individual step tooltipClass options fail to apply and override the global tour tooltipClass setting.

### Solution
Partially fixes #2105
Fixed the tooltipClass precedence logic to ensure step-level options properly override tour-level settings.

### Testing
Confirmed individual step tooltipClass options now take precedence over global tour settings
Verified HTML content renders correctly in Safari (resolving the 7.2.0 Safari issue)
Tested cross-browser compatibility

### Additional Context
While this fix is targeted at 8.2.0-beta.1, it also provides a relatively working alternative to the broken 7.2.0 version. Version 7.2.0 has a Safari-specific bug where users cannot see steps beyond the first one when using HTML content, but in 8.2.0-beta.1 steps with HTML content are working correctly.

#### Question for Maintainers
Since v8 is still in beta and many users are likely still on the stable 7.2.0 release, would it make sense to create a patch release (7.2.1) specifically for the Safari HTML content rendering bug? This would allow production users to get a stable fix without having to adopt a beta version. I'd be happy to prepare a separate PR targeting the 7.2.x branch if you think this approach would be valuable for the community. But i am unsure how to make aa PR from a 7.2.0 version since master branch is at 8,2,0-beta-1