### PR TITLE
fix(hint): remove resize listener in disableHintAutoRefresh()

### DIFF
--- a/src/packages/hint/hint.ts
+++ b/src/packages/hint/hint.ts
@@ -341,7 +341,7 @@ export class Hint implements Package<HintOptions> {
   disableHintAutoRefresh(): this {
     if (this._hintsAutoRefreshFunction) {
       DOMEvent.off(window, "scroll", this._hintsAutoRefreshFunction, true);
-      DOMEvent.on(window, "resize", this._hintsAutoRefreshFunction, true);
+      DOMEvent.off(window, "resize", this._hintsAutoRefreshFunction, true);
 
       this._hintsAutoRefreshFunction = undefined;
     }


### PR DESCRIPTION
### Problem

`disableHintAutoRefresh()` is supposed to remove the `scroll` and `resize` listeners that `enableHintAutoRefresh()` attaches. But the `resize` line uses `DOMEvent.on` instead of `DOMEvent.off`:

```ts
disableHintAutoRefresh(): this {
  if (this._hintsAutoRefreshFunction) {
    DOMEvent.off(window, "scroll", this._hintsAutoRefreshFunction, true);
    DOMEvent.on(window, "resize", this._hintsAutoRefreshFunction, true);  // <-- re-adds instead of removing

    this._hintsAutoRefreshFunction = undefined;
  }
  return this;
}
```

So after calling `disableHintAutoRefresh()`:
- the `scroll` listener is correctly removed, but
- the `resize` listener is **re-attached** (a duplicate is added), and then `this._hintsAutoRefreshFunction` is set to `undefined` — leaking the listener so it can never be removed.

This mirrors `enableHintAutoRefresh()` just above, which correctly uses `DOMEvent.on` for both events.

### Fix

Use `DOMEvent.off` for the `resize` event so both listeners are removed, matching the method's intent and its name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)